### PR TITLE
fix: use replacer function to prevent regex interpretation

### DIFF
--- a/build-standalone.js
+++ b/build-standalone.js
@@ -110,15 +110,16 @@ async function build() {
         }
 
         // Replace the external reference with inline content
+        // Use replacer function to avoid $& interpretation in replacement string
         if (info.type === 'css') {
           html = html.replace(
             new RegExp(`<link[^>]*href="${url.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}"[^>]*>`, 'i'),
-            inlineTag
+            () => inlineTag
           );
         } else {
           html = html.replace(
             new RegExp(`<script[^>]*src="${url.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}"[^>]*>`, 'i'),
-            inlineTag
+            () => inlineTag
           );
         }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "class-list-optimizer",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "A tool for optimizing class list distributions",
   "scripts": {
     "build": "node build-standalone.js"


### PR DESCRIPTION
Fixes content duplication bug in build script.

The $& pattern in React/Babel source was being interpreted as a regex replacement pattern, causing duplicated content in the built file.

Changes:
- Use replacer functions () => inlineTag instead of string replacement
- Bump version to v0.4.0