### PR TITLE
fix: simplify release workflow and add PR version check

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - main
+    types: [opened, synchronize, reopened]
 
 permissions:
   contents: read

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -1,0 +1,64 @@
+name: PR Checks
+
+on:
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  check-version-bump:
+    name: Check Version Bump
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout PR code
+        uses: actions/checkout@v4
+
+      - name: Get PR version
+        id: pr-version
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "PR package.json version: $VERSION"
+
+      - name: Checkout main branch
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          path: main-branch
+
+      - name: Get main version
+        id: main-version
+        run: |
+          VERSION=$(node -p "require('./main-branch/package.json').version")
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "Main branch version: $VERSION"
+
+      - name: Compare versions
+        run: |
+          PR_VERSION="${{ steps.pr-version.outputs.version }}"
+          MAIN_VERSION="${{ steps.main-version.outputs.version }}"
+
+          echo "Comparing versions:"
+          echo "  PR version:   $PR_VERSION"
+          echo "  Main version: $MAIN_VERSION"
+
+          if [ "$PR_VERSION" = "$MAIN_VERSION" ]; then
+            echo ""
+            echo "❌ ERROR: Version has not been bumped!"
+            echo ""
+            echo "Please update package.json version before merging:"
+            echo "  1. Edit package.json and bump the version"
+            echo "  2. Commit and push the change"
+            echo ""
+            echo "Version format: MAJOR.MINOR.PATCH"
+            echo "  - Minor bump (e.g., 0.3.0 -> 0.4.0): Increment MINOR for new features"
+            echo "  - Major bump (e.g., 0.3.0 -> 1.0.0): Increment MAJOR for breaking changes"
+            exit 1
+          fi
+
+          echo ""
+          echo "✅ Version has been bumped: $MAIN_VERSION -> $PR_VERSION"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,58 +23,12 @@ jobs:
         with:
           node-version: '20'
 
-      - name: Get PR info
-        id: pr-info
-        run: |
-          # Get the commit message to find associated PR
-          COMMIT_MSG="$(git log -1 --pretty=%B)"
-          echo "Commit message: $COMMIT_MSG"
-
-          # Check for #major in the commit message (from PR title)
-          if echo "$COMMIT_MSG" | grep -q "#major"; then
-            echo "bump_type=major" >> $GITHUB_OUTPUT
-          else
-            echo "bump_type=minor" >> $GITHUB_OUTPUT
-          fi
-
-          # Get current version from package.json
-          CURRENT_VERSION=$(node -p "require('./package.json').version")
-          echo "current_version=$CURRENT_VERSION" >> $GITHUB_OUTPUT
-
-      - name: Calculate new version
+      - name: Get version from package.json
         id: version
         run: |
-          CURRENT_VERSION="${{ steps.pr-info.outputs.current_version }}"
-          BUMP_TYPE="${{ steps.pr-info.outputs.bump_type }}"
-
-          # Parse current version
-          MAJOR=$(echo $CURRENT_VERSION | cut -d. -f1)
-          MINOR=$(echo $CURRENT_VERSION | cut -d. -f2)
-          PATCH=$(echo $CURRENT_VERSION | cut -d. -f3)
-
-          # Calculate new version
-          if [ "$BUMP_TYPE" = "major" ]; then
-            NEW_MAJOR=$((MAJOR + 1))
-            NEW_VERSION="${NEW_MAJOR}.0.0"
-            echo "Bumping MAJOR version: $CURRENT_VERSION -> $NEW_VERSION"
-          else
-            NEW_MINOR=$((MINOR + 1))
-            NEW_VERSION="${MAJOR}.${NEW_MINOR}.0"
-            echo "Bumping MINOR version: $CURRENT_VERSION -> $NEW_VERSION"
-          fi
-
-          echo "new_version=$NEW_VERSION" >> $GITHUB_OUTPUT
-
-      - name: Update package.json version
-        run: |
-          NEW_VERSION="${{ steps.version.outputs.new_version }}"
-          node -e "
-            const fs = require('fs');
-            const pkg = JSON.parse(fs.readFileSync('package.json', 'utf8'));
-            pkg.version = '$NEW_VERSION';
-            fs.writeFileSync('package.json', JSON.stringify(pkg, null, 2) + '\n');
-            console.log('Updated package.json to version $NEW_VERSION');
-          "
+          VERSION=$(node -p "require('./package.json').version")
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "Building version: $VERSION"
 
       - name: Build standalone file
         run: |
@@ -85,43 +39,36 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
-      - name: Commit version bump
+      - name: Create and push tag
         run: |
-          NEW_VERSION="${{ steps.version.outputs.new_version }}"
-          git add package.json
-          git commit -m "chore: bump version to v${NEW_VERSION} [skip ci]" || echo "No changes to commit"
-
-      - name: Push changes
-        run: |
-          git push origin main
-
-      - name: Create Git tag
-        run: |
-          NEW_VERSION="${{ steps.version.outputs.new_version }}"
-          git tag -a "v${NEW_VERSION}" -m "Release v${NEW_VERSION}"
-          git push origin "v${NEW_VERSION}"
+          VERSION="${{ steps.version.outputs.version }}"
+          # Check if tag already exists
+          if git rev-parse "v${VERSION}" >/dev/null 2>&1; then
+            echo "Tag v${VERSION} already exists, skipping"
+            exit 0
+          fi
+          git tag -a "v${VERSION}" -m "Release v${VERSION}"
+          git push origin "v${VERSION}"
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v1
         with:
-          tag_name: v${{ steps.version.outputs.new_version }}
-          name: Release v${{ steps.version.outputs.new_version }}
+          tag_name: v${{ steps.version.outputs.version }}
+          name: Release v${{ steps.version.outputs.version }}
           body: |
             ## What's Changed
 
             This release includes the bundled standalone version of Class List Optimizer.
 
-            ### Version v${{ steps.version.outputs.new_version }}
-
-            Bump type: ${{ steps.pr-info.outputs.bump_type }}
+            ### Version v${{ steps.version.outputs.version }}
 
             ### Assets
-            - **class-list-optimizer-v${{ steps.version.outputs.new_version }}.html** - Self-contained HTML file with all dependencies inlined. Works offline.
+            - **class-list-optimizer-v${{ steps.version.outputs.version }}.html** - Self-contained HTML file with all dependencies inlined. Works offline.
 
             ### Usage
             Simply download and open the HTML file in any modern web browser. No internet connection required.
           files: |
-            dist/class-list-optimizer-v${{ steps.version.outputs.new_version }}.html
+            dist/class-list-optimizer-v${{ steps.version.outputs.version }}.html
           draft: false
           prerelease: false
         env:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "class-list-optimizer",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "A tool for optimizing class list distributions",
   "scripts": {
     "build": "node build-standalone.js"


### PR DESCRIPTION
## Problem
The release workflow was trying to push commits to main (version bump), which is blocked by branch protection rules.

## Solution
1. **Simplified release workflow:**
   - Reads version directly from package.json (no auto-bump)
   - Only creates tags and releases (no commits to main)

2. **Added PR check workflow:**
   - Runs on all PRs to main
   - Compares package.json version against main
   - Fails if version hasn't been bumped
   - Provides clear error message with instructions

## Workflow Now
1. Developer bumps version in package.json before PR
2. PR check verifies version is different from main
3. On merge, release workflow creates tag and release