### PR TITLE
Fix: Student detail modal not opening

### DIFF
--- a/class-list-optimizer-source.html
+++ b/class-list-optimizer-source.html
@@ -1308,7 +1308,7 @@ function StudentDetailModal({ student, locked, onToggleLock, onClose, numericCri
 // ─────────────────────────────────────────────
 // STUDENT CARD (draggable)
 // ─────────────────────────────────────────────
-function StudentCard({ student, locked, onToggleLock, onDragStart, dragging, flagCriteria }) {
+function StudentCard({ student, locked, onToggleLock, onDragStart, dragging, flagCriteria, numericCriteria }) {
   const activeFlags = flagCriteria.filter(c => student[c.key]);
   const [showDetail, setShowDetail] = useState(false);
   const didDrag = useRef(false);
@@ -1348,6 +1348,8 @@ function StudentCard({ student, locked, onToggleLock, onDragStart, dragging, fla
           locked={locked}
           onToggleLock={onToggleLock}
           onClose={() => setShowDetail(false)}
+          numericCriteria={numericCriteria}
+          flagCriteria={flagCriteria}
         />
       )}
     </>
@@ -1427,6 +1429,7 @@ function ClassColumn({ classIdx, name, onNameChange, students, locked, onToggleL
                 onDragStart={onDragStart}
                 dragging={draggingId === s.id}
                 flagCriteria={flagCriteria}
+                numericCriteria={numericCriteria}
               />
             </React.Fragment>
           );

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "class-list-optimizer",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "A tool for optimizing class list distributions",
   "scripts": {
     "build": "node build-standalone.js"


### PR DESCRIPTION
## Summary

Fixed a bug where clicking on a student card in the Optimize view would not open the detail modal.

## Root Cause

The `StudentDetailModal` component requires `numericCriteria` and `flagCriteria` props to render student scores and flags, but `StudentCard` was not passing these props through when rendering the modal.

## Changes

- Added `numericCriteria` to `StudentCard` props
- Passed `numericCriteria` and `flagCriteria` to `StudentDetailModal` in `StudentCard`
- Passed `numericCriteria` from `ClassColumn` to `StudentCard`
- Bumped version to 0.5.1 (patch release)

## Testing

1. Go to the Optimize view
2. Click on any student card
3. The detail modal should now open showing student scores and flags