### PR TITLE
feat: add clear cache button to settings modal

### DIFF
--- a/class-list-optimizer-source.html
+++ b/class-list-optimizer-source.html
@@ -752,6 +752,7 @@ function SettingsModal({
   const [flagCriteriaState, setFlagCriteriaState] = useState(flagCriteria);
   const [error, setError] = useState('');
   const [confirmRemove, setConfirmRemove] = useState(null);
+  const [confirmClear, setConfirmClear] = useState(false);
 
   function validateWeight(val) {
     const num = parseFloat(val);
@@ -924,6 +925,12 @@ function SettingsModal({
     setFlagCriteriaState(DEFAULT_FLAG_CRITERIA.map(c => ({ ...c })));
   }
 
+  function clearSavedSettings() {
+    localStorage.removeItem(STORAGE_KEYS.NUMERIC_CRITERIA);
+    localStorage.removeItem(STORAGE_KEYS.FLAG_CRITERIA);
+    window.location.reload();
+  }
+
   const fileInputRef = useRef(null);
 
   return (
@@ -959,6 +966,7 @@ function SettingsModal({
               onChange={e => { if (e.target.files?.[0]) importConfig(e.target.files[0]); e.target.value = ''; }}
             />
             <button className="btn btn-ghost btn-sm" onClick={resetToDefaults}>Reset to Defaults</button>
+            <button className="btn btn-danger btn-sm" onClick={() => setConfirmClear(true)}>🗑 Clear Cache</button>
           </div>
 
           <div className="settings-tabs">
@@ -1090,6 +1098,26 @@ function SettingsModal({
               >
                 Remove Field
               </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {confirmClear && (
+        <div className="modal-overlay" style={{ zIndex: 1100 }}>
+          <div className="modal" style={{ maxWidth: 420 }}>
+            <div className="modal-header">
+              <div className="modal-title">Clear Saved Settings?</div>
+            </div>
+            <div className="modal-body">
+              <p style={{ fontSize: 13, color: 'var(--text2)', lineHeight: 1.6 }}>
+                This will erase your saved criteria configuration and reload the page.
+                Any student data you've entered will not be affected.
+              </p>
+            </div>
+            <div className="modal-footer">
+              <button className="btn btn-secondary" onClick={() => setConfirmClear(false)}>Cancel</button>
+              <button className="btn btn-danger" onClick={clearSavedSettings}>Clear Cache & Reload</button>
             </div>
           </div>
         </div>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "class-list-optimizer",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "description": "A tool for optimizing class list distributions",
   "scripts": {
     "build": "node build-standalone.js"


### PR DESCRIPTION
## Summary

Adds a button to clear saved criteria settings from localStorage, resolving the issue where users with old cached defaults couldn't see the new 8 flag criteria.

## Problem

When the app loads, it pulls criteria from localStorage (if they exist), overriding the new defaults. Users had to open incognito mode to bypass this. This was particularly problematic when upgrading from v0.4.x (which only had 4 flags) to v0.5.x (which has 8 flags).

## Solution

Added a "🗑 Clear Cache" button in the Settings modal that:
- Clears `localStorage` for both criteria configs
- Reloads the page to load fresh defaults
- Shows a confirmation dialog explaining that student data won't be affected

## Changes

- Added `confirmClear` state and `clearSavedSettings()` function in `SettingsModal`
- Added confirmation dialog with cancel/clear options
- Placed button next to "Reset to Defaults" in the config actions bar

## Testing

1. Open Settings modal
2. Click "🗑 Clear Cache"
3. Confirm the action
4. Page reloads with fresh defaults

## Version Bump

Bumped from 0.5.1 → 0.6.0 (minor bump for new feature)