### PR TITLE
feat: add keep-together constraint feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ Create balanced class lists in minutes. No more spreadsheet juggling.
 
 Class List Optimizer automatically distributes students across classrooms while balancing academic scores, intervention needs, gender, and more. It runs entirely in your browser: **your student data never leaves your computer.**
 
+**New in v1.4:** Student constraints — keep specific students together in the same class or apart in different classes, with clear feedback when constraints can't be satisfied.
+
 ---
 
 ## Why Use It?
@@ -14,6 +16,7 @@ Building fair class lists by hand is time-consuming and hard to get right when y
 
 - **Saves hours.** Go from a student roster to balanced class lists in minutes.
 - Balances scores, SPED, GT, ELL, behavior, interventions, gender, and class size all at once. No more juggling factors one at a time.
+- **Handles constraints:** Keep specific students together (siblings, support pairs) or apart (conflicts, separations).
 - **Consistent and defensible:** the same data always produces the same result.
 - Runs entirely in your browser with no uploads and no accounts.
 
@@ -30,6 +33,13 @@ That's it. No installation, no account, no internet connection required.
 ---
 
 ## Walkthrough
+
+1. [Configure Your Criteria](#step-1--configure-your-criteria)
+2. [Set Up Your Classes](#step-2--set-up-your-classes)
+3. [Add Your Students](#step-3--add-your-students)
+4. [Optimize](#step-4--optimize)
+5. [Set Up Constraints](#student-constraints) *(optional)*
+6. [Fine-Tuning](#fine-tuning)
 
 ### Step 1 — Configure Your Criteria
 
@@ -65,6 +75,19 @@ In the **Teachers / Classes** panel on the left:
 3. Click **⬆ Import CSV** and paste or upload your data
 
 Your CSV needs at minimum a `name` column and a `gender` column (`M` or `F`). All score and flag columns are optional — leave them blank if you don't have that data. For flag columns, use `1` or `yes` (or `true`, `y`, `x`) for yes, and `0` or leave blank for no.
+
+**Constraint Columns (optional):**
+- `keep_apart_group` — students with the same value will be kept in different classes
+- `keep_together_group` — students with the same value will be kept in the same class
+
+Example: To keep Alice and Bob apart while keeping Charlie and Diana together:
+```
+name,gender,readingScore,keep_apart_group,keep_together_group
+Alice,F,85,1,
+Bob,M,78,1,
+Charlie,M,70,,1
+Diana,F,92,,1
+```
 
 **Option B: Add students manually**
 
@@ -130,7 +153,48 @@ You can also use **Lock All** and **Unlock All** in the toolbar for bulk changes
 
 When you're happy with your class lists, click **⬇ Export Lists** in the toolbar to download a CSV with every student's name, class assignment, and all their data. Open the CSV in Excel or Google Sheets to format it, print it, or share it with your principal.
 
-> **Note:** The tool does not currently support "keep together" or "keep apart" requests between specific students. The workaround is to manually drag one of the students to the right class after optimizing, then lock them in place.
+---
+
+## Student Constraints
+
+Sometimes you need to ensure certain students end up in the same class (siblings who work well together, support pairs) or in different classes (behavior conflicts, separations). You can now specify these requirements before optimizing.
+
+### Setting Up Constraints
+
+On the Setup page, click **🔗 Constraints** to open the constraint manager.
+
+**Keep Apart** — students who must be in *different* classes (separation requests, behavioral conflicts)
+- Select 2+ students. Every pair among them will be kept apart
+- The optimizer creates all pairwise constraints automatically
+
+**Keep Together** — students who must be in the *same* class (siblings, co-taught support pairs)
+- Select 2+ students. They'll be treated as a group and placed together
+
+### How Constraints Work
+
+**Soft Constraints:** The optimizer treats constraints as high-priority requests, not absolute rules. Sometimes constraints conflict with each other or with other balance criteria. When that happens, the optimizer does its best but may not satisfy every constraint perfectly.
+
+**Understanding Violations:**
+
+If some constraints can't be satisfied, you'll see a **⚠️ X violations** badge on the Optimize page. Click it to see:
+- Which specific pairs are together when they should be apart
+- Which groups got split across classes
+- Suggestions for resolving conflicts
+
+**Why Constraints Might Be Violated:**
+
+- **Conflicting constraints:** If Alice must be apart from Bob, and Bob must be apart from Charlie, but Alice and Charlie must be together — there's no valid solution
+- **Class size limits:** If you ask 15 students to stay together but classes max at 12, the optimizer must split them
+- **Balance trade-offs:** Sometimes satisfying a constraint would make classes extremely unbalanced on other criteria
+
+### Managing Constraints
+
+- **From Setup:** Click **🔗 Constraints** anytime to add or remove constraints
+- **From Optimize:** The Constraints button is also available on the results page
+- **Constraints are cleared** when you import new students or clear the roster
+- **CSV Import/Export:** Save constraints in your CSV using the `keep_apart_group` and `keep_together_group` columns
+
+> **Pro tip:** Start with your most important constraints first. The fewer constraints you have, the more likely they'll all be satisfied. You can always add more and re-optimize.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -6,8 +6,6 @@ Create balanced class lists in minutes. No more spreadsheet juggling.
 
 Class List Optimizer automatically distributes students across classrooms while balancing academic scores, intervention needs, gender, and more. It runs entirely in your browser: **your student data never leaves your computer.**
 
-**New in v1.4:** Student constraints — keep specific students together in the same class or apart in different classes, with clear feedback when constraints can't be satisfied.
-
 ---
 
 ## Why Use It?
@@ -33,13 +31,6 @@ That's it. No installation, no account, no internet connection required.
 ---
 
 ## Walkthrough
-
-1. [Configure Your Criteria](#step-1--configure-your-criteria)
-2. [Set Up Your Classes](#step-2--set-up-your-classes)
-3. [Add Your Students](#step-3--add-your-students)
-4. [Optimize](#step-4--optimize)
-5. [Set Up Constraints](#student-constraints) *(optional)*
-6. [Fine-Tuning](#fine-tuning)
 
 ### Step 1 — Configure Your Criteria
 
@@ -80,7 +71,7 @@ Your CSV needs at minimum a `name` column and a `gender` column (`M` or `F`). Al
 - `keep_apart_group` — students with the same value will be kept in different classes
 - `keep_together_group` — students with the same value will be kept in the same class
 
-Example: To keep Alice and Bob apart while keeping Charlie and Diana together:
+Example CSV:
 ```
 name,gender,readingScore,keep_apart_group,keep_together_group
 Alice,F,85,1,
@@ -149,52 +140,23 @@ You can also use **Lock All** and **Unlock All** in the toolbar for bulk changes
 
 > **Recommended workflow:** Run the initial optimization first. Then lock any students where you need to override the placement, and click Re-Optimize to let the optimizer work around your manual decisions.
 
+### Student Constraints
+
+Click **🔗 Constraints** on the Setup page to keep specific students together or apart:
+
+- **Keep Apart** — select 2+ students; each pair will be placed in different classes
+- **Keep Together** — select 2+ students; they'll be placed in the same class
+
+Constraints are treated as high-priority requests, not absolute rules. If the optimizer can't satisfy all constraints, you'll see a **⚠️ X violations** badge. Click it to see which constraints were violated and why. Common reasons:
+- Conflicting constraints (e.g., A must be with B, but A must be apart from C, and B and C are together)
+- Class size limits (asking 15 students to stay together when classes max at 12)
+- Balance trade-offs where satisfying constraints would make classes extremely unbalanced
+
+Constraints are cleared when you import new students. Use the `keep_apart_group` and `keep_together_group` CSV columns to persist them.
+
 ### Export
 
 When you're happy with your class lists, click **⬇ Export Lists** in the toolbar to download a CSV with every student's name, class assignment, and all their data. Open the CSV in Excel or Google Sheets to format it, print it, or share it with your principal.
-
----
-
-## Student Constraints
-
-Sometimes you need to ensure certain students end up in the same class (siblings who work well together, support pairs) or in different classes (behavior conflicts, separations). You can now specify these requirements before optimizing.
-
-### Setting Up Constraints
-
-On the Setup page, click **🔗 Constraints** to open the constraint manager.
-
-**Keep Apart** — students who must be in *different* classes (separation requests, behavioral conflicts)
-- Select 2+ students. Every pair among them will be kept apart
-- The optimizer creates all pairwise constraints automatically
-
-**Keep Together** — students who must be in the *same* class (siblings, co-taught support pairs)
-- Select 2+ students. They'll be treated as a group and placed together
-
-### How Constraints Work
-
-**Soft Constraints:** The optimizer treats constraints as high-priority requests, not absolute rules. Sometimes constraints conflict with each other or with other balance criteria. When that happens, the optimizer does its best but may not satisfy every constraint perfectly.
-
-**Understanding Violations:**
-
-If some constraints can't be satisfied, you'll see a **⚠️ X violations** badge on the Optimize page. Click it to see:
-- Which specific pairs are together when they should be apart
-- Which groups got split across classes
-- Suggestions for resolving conflicts
-
-**Why Constraints Might Be Violated:**
-
-- **Conflicting constraints:** If Alice must be apart from Bob, and Bob must be apart from Charlie, but Alice and Charlie must be together — there's no valid solution
-- **Class size limits:** If you ask 15 students to stay together but classes max at 12, the optimizer must split them
-- **Balance trade-offs:** Sometimes satisfying a constraint would make classes extremely unbalanced on other criteria
-
-### Managing Constraints
-
-- **From Setup:** Click **🔗 Constraints** anytime to add or remove constraints
-- **From Optimize:** The Constraints button is also available on the results page
-- **Constraints are cleared** when you import new students or clear the roster
-- **CSV Import/Export:** Save constraints in your CSV using the `keep_apart_group` and `keep_together_group` columns
-
-> **Pro tip:** Start with your most important constraints first. The fewer constraints you have, the more likely they'll all be satisfied. You can always add more and re-optimize.
 
 ---
 

--- a/src/app.js
+++ b/src/app.js
@@ -21,6 +21,9 @@ function App() {
   // Keep apart constraints: array of [studentId1, studentId2] pairs
   const [keepApart, setKeepApart] = useState([]);
 
+  // Keep together constraints: array of student ID groups
+  const [keepTogether, setKeepTogether] = useState([]);
+
   const [showSettings, setShowSettings] = useState(false);
 
   // Persist criteria to localStorage
@@ -55,9 +58,30 @@ function App() {
     setKeepApart(prev => prev.filter(p => !(p[0] === pair[0] && p[1] === pair[1])));
   }
 
+  // Add a keep-together group
+  function addKeepTogether(studentIds) {
+    if (studentIds.length < 2) return;
+    const sortedIds = [...studentIds].sort();
+    setKeepTogether(prev => {
+      // Don't add duplicates (check if same group already exists)
+      const exists = prev.some(group =>
+        group.length === sortedIds.length &&
+        group.every((id, i) => id === sortedIds[i])
+      );
+      if (exists) return prev;
+      return [...prev, sortedIds];
+    });
+  }
+
+  // Remove a keep-together group
+  function removeKeepTogether(groupIndex) {
+    setKeepTogether(prev => prev.filter((_, i) => i !== groupIndex));
+  }
+
   // Remove all constraints involving a student (when student is deleted)
   function removeStudentConstraints(studentId) {
     setKeepApart(prev => prev.filter(p => p[0] !== studentId && p[1] !== studentId));
+    setKeepTogether(prev => prev.filter(group => !group.includes(studentId)));
   }
 
   function handleSaveSettings(newNumCriteria, newFlagCriteria) {
@@ -126,6 +150,9 @@ function App() {
           keepApart={keepApart}
           onAddKeepApart={addKeepApart}
           onRemoveKeepApart={removeKeepApart}
+          keepTogether={keepTogether}
+          onAddKeepTogether={addKeepTogether}
+          onRemoveKeepTogether={removeKeepTogether}
           onRemoveStudentConstraints={removeStudentConstraints}
         />
       ) : (
@@ -137,6 +164,11 @@ function App() {
           numericCriteria={numericCriteria}
           flagCriteria={flagCriteria}
           keepApart={keepApart}
+          onAddKeepApart={addKeepApart}
+          onRemoveKeepApart={removeKeepApart}
+          keepTogether={keepTogether}
+          onAddKeepTogether={addKeepTogether}
+          onRemoveKeepTogether={removeKeepTogether}
         />
       )}
 

--- a/src/components/ConstraintManager.js
+++ b/src/components/ConstraintManager.js
@@ -3,8 +3,12 @@ function ConstraintManager({
   keepApart,
   onAddKeepApart,
   onRemoveKeepApart,
+  keepTogether,
+  onAddKeepTogether,
+  onRemoveKeepTogether,
   onClose,
 }) {
+  const [activeTab, setActiveTab] = useState('apart'); // 'apart' | 'together'
   const [selectedIds, setSelectedIds] = useState([]);
   const [filter, setFilter] = useState('');
 
@@ -15,195 +19,485 @@ function ConstraintManager({
     s.name.toLowerCase().includes(filter.toLowerCase())
   );
 
-  // Get groups (connected components) from keepApart pairs
-  function getGroups() {
-    const groups = [];
-    const visited = new Set();
-    const adj = {};
+  // Get apart constraint pairs with student info
+  const apartConstraints = keepApart.map(([id1, id2]) => ({
+    id1,
+    id2,
+    name1: studentById[id1]?.name || id1,
+    name2: studentById[id2]?.name || id2,
+  }));
 
-    // Build adjacency list
-    students.forEach(s => { adj[s.id] = []; });
-    keepApart.forEach(([id1, id2]) => {
-      if (adj[id1]) adj[id1].push(id2);
-      if (adj[id2]) adj[id2].push(id1);
-    });
+  // Get together constraint groups with student info
+  const togetherConstraints = keepTogether.map((group, idx) => ({
+    idx,
+    studentIds: group,
+    names: group.map(id => studentById[id]?.name || id),
+  }));
 
-    // Find connected components
-    students.forEach(s => {
-      if (visited.has(s.id)) return;
-      const group = [];
-      const stack = [s.id];
-      while (stack.length > 0) {
-        const id = stack.pop();
-        if (visited.has(id)) continue;
-        visited.add(id);
-        group.push(id);
-        adj[id].forEach(neighbor => {
-          if (!visited.has(neighbor)) stack.push(neighbor);
-        });
-      }
-      if (group.length > 1) groups.push(group);
-    });
+  // Build adjacency list for keep-apart
+  const apartAdj = {};
+  students.forEach(s => { apartAdj[s.id] = []; });
+  keepApart.forEach(([id1, id2]) => {
+    if (apartAdj[id1]) apartAdj[id1].push(id2);
+    if (apartAdj[id2]) apartAdj[id2].push(id1);
+  });
 
-    return groups;
-  }
-
-  const groups = getGroups();
+  // Build set of students in keep-together groups
+  const togetherStudentSet = new Set();
+  keepTogether.forEach(group => {
+    group.forEach(id => togetherStudentSet.add(id));
+  });
 
   function toggleSelection(id) {
     setSelectedIds(prev => {
       if (prev.includes(id)) {
         return prev.filter(x => x !== id);
       }
-      if (prev.length >= 2) {
-        return [prev[1], id]; // Keep last selected, add new
-      }
       return [...prev, id];
     });
   }
 
-  function handleAddConstraint() {
-    if (selectedIds.length === 2) {
-      onAddKeepApart(selectedIds[0], selectedIds[1]);
+  function handleAddApartConstraint() {
+    if (selectedIds.length >= 2) {
+      // Add pairwise constraints for all selected students
+      for (let i = 0; i < selectedIds.length; i++) {
+        for (let j = i + 1; j < selectedIds.length; j++) {
+          onAddKeepApart(selectedIds[i], selectedIds[j]);
+        }
+      }
       setSelectedIds([]);
     }
   }
 
-  function handleRemoveFromGroup(id1, id2) {
+  function handleAddTogetherConstraint() {
+    if (selectedIds.length >= 2) {
+      onAddKeepTogether(selectedIds);
+      setSelectedIds([]);
+    }
+  }
+
+  function handleRemoveApartConstraint(id1, id2) {
     onRemoveKeepApart(id1, id2);
   }
 
+  function handleRemoveTogetherConstraint(idx) {
+    onRemoveKeepTogether(idx);
+  }
+
+  // Get related students for the selected group (apart mode only)
+  function getSelectedGroupInfo() {
+    if (activeTab !== 'apart' || selectedIds.length === 0) return null;
+    
+    const selectedSet = new Set(selectedIds);
+    const related = new Set();
+    
+    selectedIds.forEach(id => {
+      apartAdj[id].forEach(neighbor => {
+        if (!selectedSet.has(neighbor)) {
+          related.add(neighbor);
+        }
+      });
+    });
+    
+    return {
+      selected: selectedIds.map(id => studentById[id]?.name || id),
+      related: Array.from(related).map(id => studentById[id]?.name || id),
+    };
+  }
+
+  const groupInfo = getSelectedGroupInfo();
+
+  // Count total constraints
+  const totalConstraints = keepApart.length + keepTogether.length;
+
   return (
     <div className="modal-overlay" onClick={onClose}>
-      <div className="modal" onClick={e => e.stopPropagation()} style={{ maxWidth: 600, width: '90%' }}>
+      <div className="modal" onClick={e => e.stopPropagation()} style={{ maxWidth: 700, width: '90%' }}>
         <div className="modal-header">
           <h3 style={{ margin: 0 }}>Student Constraints</h3>
           <button className="btn btn-ghost btn-sm" onClick={onClose}>✕</button>
         </div>
 
-        <div className="modal-body" style={{ padding: 20 }}>
-          {/* Existing Constraints */}
-          <div style={{ marginBottom: 24 }}>
-            <h4 style={{ margin: '0 0 12px 0', fontSize: 14, fontWeight: 500 }}>Keep Apart Groups</h4>
-            {groups.length === 0 ? (
-              <div style={{ color: 'var(--text3)', fontSize: 13, padding: '12px 0' }}>
-                No keep-apart constraints set yet.
-              </div>
-            ) : (
-              <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
-                {groups.map((group, idx) => (
-                  <div key={idx} className="constraint-group" style={{
-                    background: 'var(--surface)',
-                    border: '1px solid var(--border)',
-                    borderRadius: 'var(--radius-sm)',
-                    padding: 12,
-                  }}>
-                    <div style={{ display: 'flex', alignItems: 'center', gap: 8, flexWrap: 'wrap' }}>
-                      <span style={{ fontSize: 12, color: 'var(--text3)', marginRight: 8 }}>
-                        Group {idx + 1}:
-                      </span>
-                      {group.map((id, i) => (
-                        <React.Fragment key={id}>
-                          <span className="badge" style={{ background: 'var(--bg)', color: 'var(--text)' }}>
-                            {studentById[id]?.name || id}
-                          </span>
-                          {i < group.length - 1 && (
-                            <span style={{ color: 'var(--text3)' }}>↔</span>
-                          )}
-                        </React.Fragment>
-                      ))}
-                      <button
-                        className="btn btn-danger btn-sm"
-                        style={{ marginLeft: 'auto' }}
-                        onClick={() => {
-                          // Remove all pairs within this group
-                          for (let i = 0; i < group.length; i++) {
-                            for (let j = i + 1; j < group.length; j++) {
-                              handleRemoveFromGroup(group[i], group[j]);
-                            }
-                          }
-                        }}
-                      >
-                        Remove
-                      </button>
-                    </div>
-                  </div>
-                ))}
-              </div>
-            )}
+        <div className="modal-body" style={{ padding: 0 }}>
+          {/* Tabs */}
+          <div style={{
+            display: 'flex',
+            borderBottom: '1px solid var(--border)',
+            background: 'var(--surface)',
+          }}>
+            <button
+              onClick={() => { setActiveTab('apart'); setSelectedIds([]); setFilter(''); }}
+              style={{
+                padding: '12px 20px',
+                border: 'none',
+                background: activeTab === 'apart' ? 'var(--bg)' : 'transparent',
+                borderBottom: activeTab === 'apart' ? '2px solid var(--accent)' : '2px solid transparent',
+                color: activeTab === 'apart' ? 'var(--accent)' : 'var(--text2)',
+                fontSize: 14,
+                fontWeight: 500,
+                cursor: 'pointer',
+                display: 'flex',
+                alignItems: 'center',
+                gap: 8,
+              }}
+            >
+              Keep Apart
+              {keepApart.length > 0 && (
+                <span className="badge" style={{ background: 'var(--danger)', color: 'white', fontSize: 10 }}>
+                  {keepApart.length}
+                </span>
+              )}
+            </button>
+            <button
+              onClick={() => { setActiveTab('together'); setSelectedIds([]); setFilter(''); }}
+              style={{
+                padding: '12px 20px',
+                border: 'none',
+                background: activeTab === 'together' ? 'var(--bg)' : 'transparent',
+                borderBottom: activeTab === 'together' ? '2px solid var(--accent)' : '2px solid transparent',
+                color: activeTab === 'together' ? 'var(--accent)' : 'var(--text2)',
+                fontSize: 14,
+                fontWeight: 500,
+                cursor: 'pointer',
+                display: 'flex',
+                alignItems: 'center',
+                gap: 8,
+              }}
+            >
+              Keep Together
+              {keepTogether.length > 0 && (
+                <span className="badge" style={{ background: 'var(--accent)', color: 'white', fontSize: 10 }}>
+                  {keepTogether.length}
+                </span>
+              )}
+            </button>
           </div>
 
-          {/* Add New Constraint */}
-          <div>
-            <h4 style={{ margin: '0 0 12px 0', fontSize: 14, fontWeight: 500 }}>Add Keep-Apart Constraint</h4>
-            <p style={{ margin: '0 0 12px 0', fontSize: 12, color: 'var(--text3)' }}>
-              Select two students who should be placed in different classes.
-            </p>
-
-            <input
-              type="text"
-              className="form-input"
-              placeholder="Filter students by name..."
-              value={filter}
-              onChange={e => setFilter(e.target.value)}
-              style={{ marginBottom: 12 }}
-            />
-
-            <div style={{
-              maxHeight: 200,
-              overflow: 'auto',
-              border: '1px solid var(--border)',
-              borderRadius: 'var(--radius-sm)',
-              marginBottom: 12,
-            }}>
-              {filteredStudents.length === 0 ? (
-                <div style={{ padding: 16, color: 'var(--text3)', textAlign: 'center' }}>
-                  No students match your filter.
+          <div style={{ padding: 20 }}>
+            {activeTab === 'apart' ? (
+              <>
+                {/* Keep Apart Existing Constraints */}
+                <div style={{ marginBottom: 24 }}>
+                  <h4 style={{ margin: '0 0 12px 0', fontSize: 14, fontWeight: 500 }}>
+                    Active Keep-Apart Constraints ({apartConstraints.length})
+                  </h4>
+                  {apartConstraints.length === 0 ? (
+                    <div style={{ color: 'var(--text3)', fontSize: 13, padding: '12px 0' }}>
+                      No keep-apart constraints set yet. These students will be placed in different classes.
+                    </div>
+                  ) : (
+                    <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+                      {apartConstraints.map((c, idx) => (
+                        <div key={idx} className="constraint-item" style={{
+                          background: 'var(--surface)',
+                          border: '1px solid var(--border)',
+                          borderRadius: 'var(--radius-sm)',
+                          padding: '8px 12px',
+                        }}>
+                          <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+                            <span className="badge" style={{ background: 'var(--bg)', color: 'var(--text)' }}>
+                              {c.name1}
+                            </span>
+                            <span style={{ color: 'var(--text3)' }}>↔</span>
+                            <span className="badge" style={{ background: 'var(--bg)', color: 'var(--text)' }}>
+                              {c.name2}
+                            </span>
+                            <span style={{ 
+                              marginLeft: 'auto', 
+                              fontSize: 11, 
+                              color: 'var(--text3)',
+                              fontStyle: 'italic'
+                            }}>
+                              {apartAdj[c.id1].length > 1 && `${apartAdj[c.id1].length - 1} other constraints`}
+                            </span>
+                            <button
+                              className="btn btn-danger btn-sm"
+                              onClick={() => handleRemoveApartConstraint(c.id1, c.id2)}
+                              title="Remove this constraint"
+                            >
+                              ✕
+                            </button>
+                          </div>
+                        </div>
+                      ))}
+                    </div>
+                  )}
                 </div>
-              ) : (
-                filteredStudents.map(s => (
-                  <div
-                    key={s.id}
-                    onClick={() => toggleSelection(s.id)}
-                    style={{
-                      padding: '8px 12px',
-                      cursor: 'pointer',
-                      background: selectedIds.includes(s.id) ? 'var(--accent)' : 'transparent',
-                      color: selectedIds.includes(s.id) ? 'white' : 'var(--text)',
-                      borderBottom: '1px solid var(--border)',
-                      display: 'flex',
-                      alignItems: 'center',
-                      gap: 8,
-                    }}
-                  >
-                    <input
-                      type="checkbox"
-                      checked={selectedIds.includes(s.id)}
-                      onChange={() => {}}
-                      style={{ pointerEvents: 'none' }}
-                    />
-                    <span>{s.name}</span>
-                    <span className={`badge badge-${s.gender}`} style={{ marginLeft: 'auto' }}>
-                      {s.gender}
-                    </span>
-                  </div>
-                ))
-              )}
-            </div>
 
-            <div style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
-              <span style={{ fontSize: 13 }}>
-                Selected: {selectedIds.length === 0 ? 'None' : selectedIds.map(id => studentById[id]?.name).join(' + ')}
-              </span>
-              <button
-                className="btn btn-primary btn-sm"
-                disabled={selectedIds.length !== 2}
-                onClick={handleAddConstraint}
-                style={{ marginLeft: 'auto' }}
-              >
-                Add Constraint
-              </button>
-            </div>
+                {/* Keep Apart Add New */}
+                <div>
+                  <h4 style={{ margin: '0 0 12px 0', fontSize: 14, fontWeight: 500 }}>
+                    Add Keep-Apart Constraint
+                  </h4>
+                  <p style={{ margin: '0 0 12px 0', fontSize: 12, color: 'var(--text3)' }}>
+                    Select 2+ students. Each pair will be kept in different classes.
+                  </p>
+
+                  <input
+                    type="text"
+                    className="form-input"
+                    placeholder="Filter students by name..."
+                    value={filter}
+                    onChange={e => setFilter(e.target.value)}
+                    style={{ marginBottom: 12 }}
+                  />
+
+                  <div style={{
+                    maxHeight: 200,
+                    overflow: 'auto',
+                    border: '1px solid var(--border)',
+                    borderRadius: 'var(--radius-sm)',
+                    marginBottom: 12,
+                  }}>
+                    {filteredStudents.length === 0 ? (
+                      <div style={{ padding: 16, color: 'var(--text3)', textAlign: 'center' }}>
+                        No students match your filter.
+                      </div>
+                    ) : (
+                      filteredStudents.map(s => (
+                        <div
+                          key={s.id}
+                          onClick={() => toggleSelection(s.id)}
+                          style={{
+                            padding: '8px 12px',
+                            cursor: 'pointer',
+                            background: selectedIds.includes(s.id) ? 'var(--accent)' : 'transparent',
+                            color: selectedIds.includes(s.id) ? 'white' : 'var(--text)',
+                            borderBottom: '1px solid var(--border)',
+                            display: 'flex',
+                            alignItems: 'center',
+                            gap: 8,
+                          }}
+                        >
+                          <input
+                            type="checkbox"
+                            checked={selectedIds.includes(s.id)}
+                            onChange={() => {}}
+                            style={{ pointerEvents: 'none' }}
+                          />
+                          <span>{s.name}</span>
+                          {apartAdj[s.id].length > 0 && (
+                            <span style={{ 
+                              fontSize: 10, 
+                              marginLeft: 8,
+                              opacity: 0.7 
+                            }}>
+                              ({apartAdj[s.id].length} apart constraints)
+                            </span>
+                          )}
+                          <span className={`badge badge-${s.gender}`} style={{ marginLeft: 'auto' }}>
+                            {s.gender}
+                          </span>
+                        </div>
+                      ))
+                    )}
+                  </div>
+
+                  {/* Selection summary */}
+                  {selectedIds.length > 0 && (
+                    <div style={{ 
+                      marginBottom: 12, 
+                      padding: 12, 
+                      background: 'var(--surface)', 
+                      borderRadius: 'var(--radius-sm)',
+                      border: '1px solid var(--border)'
+                    }}>
+                      <div style={{ fontSize: 13, marginBottom: 8 }}>
+                        <strong>Selected ({selectedIds.length}):</strong>{' '}
+                        {selectedIds.map(id => studentById[id]?.name).join(', ')}
+                      </div>
+                      {selectedIds.length >= 2 && (
+                        <div style={{ fontSize: 12, color: 'var(--text3)' }}>
+                          Will create {Math.floor(selectedIds.length * (selectedIds.length - 1) / 2)} pairwise constraints
+                        </div>
+                      )}
+                      {groupInfo && groupInfo.related.length > 0 && (
+                        <div style={{ fontSize: 11, color: 'var(--warning)', marginTop: 8 }}>
+                          Note: Some selected students already have apart constraints with: {groupInfo.related.join(', ')}
+                        </div>
+                      )}
+                    </div>
+                  )}
+
+                  <div style={{ display: 'flex', alignItems: 'center', gap: 12, justifyContent: 'flex-end' }}>
+                    {selectedIds.length > 0 && (
+                      <button
+                        className="btn btn-ghost btn-sm"
+                        onClick={() => setSelectedIds([])}
+                      >
+                        Clear Selection
+                      </button>
+                    )}
+                    <button
+                      className="btn btn-primary btn-sm"
+                      disabled={selectedIds.length < 2}
+                      onClick={handleAddApartConstraint}
+                    >
+                      Add {selectedIds.length >= 2 ? Math.floor(selectedIds.length * (selectedIds.length - 1) / 2) : 0} Constraint{selectedIds.length > 3 ? 's' : ''}
+                    </button>
+                  </div>
+                </div>
+              </>
+            ) : (
+              <>
+                {/* Keep Together Existing Constraints */}
+                <div style={{ marginBottom: 24 }}>
+                  <h4 style={{ margin: '0 0 12px 0', fontSize: 14, fontWeight: 500 }}>
+                    Active Keep-Together Groups ({togetherConstraints.length})
+                  </h4>
+                  {togetherConstraints.length === 0 ? (
+                    <div style={{ color: 'var(--text3)', fontSize: 13, padding: '12px 0' }}>
+                      No keep-together constraints set yet. These students will be placed in the same class.
+                    </div>
+                  ) : (
+                    <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+                      {togetherConstraints.map((c) => (
+                        <div key={c.idx} className="constraint-item" style={{
+                          background: 'var(--surface)',
+                          border: '1px solid var(--border)',
+                          borderRadius: 'var(--radius-sm)',
+                          padding: '8px 12px',
+                        }}>
+                          <div style={{ display: 'flex', alignItems: 'center', gap: 8, flexWrap: 'wrap' }}>
+                            <span style={{ fontSize: 12, color: 'var(--accent)', fontWeight: 500, marginRight: 8 }}>
+                              Group {c.idx + 1}:
+                            </span>
+                            {c.names.map((name, i) => (
+                              <span key={i}>
+                                <span className="badge" style={{ background: 'var(--bg)', color: 'var(--text)' }}>
+                                  {name}
+                                </span>
+                                {i < c.names.length - 1 && (
+                                  <span style={{ color: 'var(--text3)', margin: '0 4px' }}>+</span>
+                                )}
+                              </span>
+                            ))}
+                            <button
+                              className="btn btn-danger btn-sm"
+                              onClick={() => handleRemoveTogetherConstraint(c.idx)}
+                              title="Remove this group"
+                              style={{ marginLeft: 'auto' }}
+                            >
+                              ✕
+                            </button>
+                          </div>
+                        </div>
+                      ))}
+                    </div>
+                  )}
+                </div>
+
+                {/* Keep Together Add New */}
+                <div>
+                  <h4 style={{ margin: '0 0 12px 0', fontSize: 14, fontWeight: 500 }}>
+                    Add Keep-Together Group
+                  </h4>
+                  <p style={{ margin: '0 0 12px 0', fontSize: 12, color: 'var(--text3)' }}>
+                    Select 2+ students. They will be placed in the same class.
+                  </p>
+
+                  <input
+                    type="text"
+                    className="form-input"
+                    placeholder="Filter students by name..."
+                    value={filter}
+                    onChange={e => setFilter(e.target.value)}
+                    style={{ marginBottom: 12 }}
+                  />
+
+                  <div style={{
+                    maxHeight: 200,
+                    overflow: 'auto',
+                    border: '1px solid var(--border)',
+                    borderRadius: 'var(--radius-sm)',
+                    marginBottom: 12,
+                  }}>
+                    {filteredStudents.length === 0 ? (
+                      <div style={{ padding: 16, color: 'var(--text3)', textAlign: 'center' }}>
+                        No students match your filter.
+                      </div>
+                    ) : (
+                      filteredStudents.map(s => (
+                        <div
+                          key={s.id}
+                          onClick={() => toggleSelection(s.id)}
+                          style={{
+                            padding: '8px 12px',
+                            cursor: 'pointer',
+                            background: selectedIds.includes(s.id) ? 'var(--accent)' : 'transparent',
+                            color: selectedIds.includes(s.id) ? 'white' : 'var(--text)',
+                            borderBottom: '1px solid var(--border)',
+                            display: 'flex',
+                            alignItems: 'center',
+                            gap: 8,
+                          }}
+                        >
+                          <input
+                            type="checkbox"
+                            checked={selectedIds.includes(s.id)}
+                            onChange={() => {}}
+                            style={{ pointerEvents: 'none' }}
+                          />
+                          <span>{s.name}</span>
+                          {togetherStudentSet.has(s.id) && (
+                            <span style={{ 
+                              fontSize: 10, 
+                              marginLeft: 8,
+                              opacity: 0.7,
+                              color: 'var(--accent)'
+                            }}>
+                              (in group)
+                            </span>
+                          )}
+                          <span className={`badge badge-${s.gender}`} style={{ marginLeft: 'auto' }}>
+                            {s.gender}
+                          </span>
+                        </div>
+                      ))
+                    )}
+                  </div>
+
+                  {/* Selection summary */}
+                  {selectedIds.length > 0 && (
+                    <div style={{ 
+                      marginBottom: 12, 
+                      padding: 12, 
+                      background: 'var(--surface)', 
+                      borderRadius: 'var(--radius-sm)',
+                      border: '1px solid var(--border)'
+                    }}>
+                      <div style={{ fontSize: 13, marginBottom: 8 }}>
+                        <strong>Selected ({selectedIds.length}):</strong>{' '}
+                        {selectedIds.map(id => studentById[id]?.name).join(', ')}
+                      </div>
+                      {selectedIds.length >= 2 && (
+                        <div style={{ fontSize: 12, color: 'var(--text3)' }}>
+                          Will create 1 keep-together group
+                        </div>
+                      )}
+                    </div>
+                  )}
+
+                  <div style={{ display: 'flex', alignItems: 'center', gap: 12, justifyContent: 'flex-end' }}>
+                    {selectedIds.length > 0 && (
+                      <button
+                        className="btn btn-ghost btn-sm"
+                        onClick={() => setSelectedIds([])}
+                      >
+                        Clear Selection
+                      </button>
+                    )}
+                    <button
+                      className="btn btn-primary btn-sm"
+                      disabled={selectedIds.length < 2}
+                      onClick={handleAddTogetherConstraint}
+                    >
+                      Add Group
+                    </button>
+                  </div>
+                </div>
+              </>
+            )}
           </div>
         </div>
 

--- a/src/components/ImportModal.js
+++ b/src/components/ImportModal.js
@@ -2,18 +2,18 @@ function ImportModal({ onImport, onClose, numericCriteria, flagCriteria, onImpor
   const [text, setText] = useState('');
   const [error, setError] = useState('');
 
-  const csvTemplate = generateCSVHeaders(numericCriteria, flagCriteria).join(',') + ',keep_apart_group\n' +
-    'Smith Emma,F,' + numericCriteria.map(() => '75').join(',') + ',' + flagCriteria.map(() => '0').join(',') + ',\n' +
-    'Johnson Liam,M,' + numericCriteria.map(() => '82').join(',') + ',' + flagCriteria.map(() => '1').join(',') + ',';
+  const csvTemplate = generateCSVHeaders(numericCriteria, flagCriteria).join(',') + ',keep_apart_group,keep_together_group\n' +
+    'Smith Emma,F,' + numericCriteria.map(() => '75').join(',') + ',' + flagCriteria.map(() => '0').join(',') + ',,\n' +
+    'Johnson Liam,M,' + numericCriteria.map(() => '82').join(',') + ',' + flagCriteria.map(() => '1').join(',') + ',,';
 
   function handleImport() {
-    const { students, errors, keepApart } = parseCSV(text, numericCriteria, flagCriteria);
+    const { students, errors, keepApart, keepTogether } = parseCSV(text, numericCriteria, flagCriteria);
     if (!students.length) {
       setError(errors.length ? errors.join('; ') : 'No valid students found. Check your CSV format.');
       return;
     }
     if (errors.length) setError(`Imported ${students.length} students with warnings: ${errors.join('; ')}`);
-    onImport(students, keepApart);
+    onImport(students, keepApart, keepTogether);
     if (!errors.length) onClose();
   }
 

--- a/src/components/OptimizePage.js
+++ b/src/components/OptimizePage.js
@@ -6,11 +6,17 @@ function OptimizePage({
   numericCriteria,
   flagCriteria,
   keepApart = [],
+  onAddKeepApart,
+  onRemoveKeepApart,
+  keepTogether = [],
+  onAddKeepTogether,
+  onRemoveKeepTogether,
 }) {
   const [assignment, setAssignment] = useState({});
   const [locked, setLocked] = useState(new Set());
   const [draggingId, setDraggingId] = useState(null);
   const [showHelp, setShowHelp] = useState(false);
+  const [showConstraints, setShowConstraints] = useState(false);
   const [cost, setCost] = useState(null);
   const [optimizing, setOptimizing] = useState(false);
   const [fullscreen, setFullscreen] = useState(false);
@@ -28,9 +34,9 @@ function OptimizePage({
     setTimeout(() => {
       const lockedObj = {};
       lockedAssignments.forEach((classIdx, sid) => { lockedObj[sid] = classIdx; });
-      const result = optimize(students, numClasses, lockedObj, numericCriteria, flagCriteria, keepApart);
+      const result = optimize(students, numClasses, lockedObj, numericCriteria, flagCriteria, keepApart, keepTogether);
       setAssignment(result);
-      setCost(computeCost(students, result, numClasses, numericCriteria, flagCriteria, keepApart));
+      setCost(computeCost(students, result, numClasses, numericCriteria, flagCriteria, keepApart, keepTogether));
       setOptimizing(false);
     }, 30);
   }
@@ -71,16 +77,30 @@ function OptimizePage({
     if (!sid) return;
     const newAssignment = { ...assignment, [sid]: classIdx };
     setAssignment(newAssignment);
-    setCost(computeCost(students, newAssignment, numClasses, numericCriteria, flagCriteria, keepApart));
+    setCost(computeCost(students, newAssignment, numClasses, numericCriteria, flagCriteria, keepApart, keepTogether));
     setDraggingId(null);
   }
 
   // Calculate keep-apart violations for display
-  const violations = keepApart.filter(([id1, id2]) => {
+  const apartViolations = keepApart.filter(([id1, id2]) => {
     const c1 = assignment[id1];
     const c2 = assignment[id2];
     return c1 !== undefined && c2 !== undefined && c1 === c2;
   });
+
+  // Calculate keep-together violations for display
+  const togetherViolations = keepTogether.filter(group => {
+    if (group.length < 2) return false;
+    const classes = new Set();
+    for (const id of group) {
+      const c = assignment[id];
+      if (c !== undefined) classes.add(c);
+    }
+    return classes.size > 1;
+  });
+
+  // Total violations
+  const totalViolations = apartViolations.length + togetherViolations.length;
 
   const classesByIdx = Array.from({ length: numClasses }, (_, i) =>
     students.filter(s => assignment[s.id] === i)
@@ -120,10 +140,10 @@ function OptimizePage({
             <span style={{ fontSize: 10, color: 'var(--text3)' }}>(lower is better)</span>
           </div>
         )}
-        {violations.length > 0 && (
-          <div className="violations-badge" title={`${violations.length} keep-apart constraint(s) violated`}>
+        {totalViolations > 0 && (
+          <div className="violations-badge" title={`${apartViolations.length} keep-apart, ${togetherViolations.length} keep-together constraint(s) violated`}>
             <span style={{ color: 'var(--danger)', fontSize: 12, fontWeight: 500 }}>
-              ⚠️ {violations.length} violation{violations.length === 1 ? '' : 's'}
+              ⚠️ {totalViolations} violation{totalViolations === 1 ? '' : 's'}
             </span>
           </div>
         )}
@@ -136,6 +156,13 @@ function OptimizePage({
               </span>
             ))}
           </div>
+          <button
+            className="btn btn-secondary btn-sm"
+            onClick={() => setShowConstraints(true)}
+            title="View and edit constraints"
+          >
+            🔗 Constraints {(keepApart.length + keepTogether.length) > 0 && `(${keepApart.length + keepTogether.length})`}
+          </button>
           <button
             className="btn btn-secondary btn-sm"
             onClick={() => triggerDownload(exportClassListsToCSV(students, assignment, teachers, numericCriteria, flagCriteria), 'class-lists.csv', 'text/csv')}
@@ -192,6 +219,19 @@ function OptimizePage({
       />}
 
       {showHelp && <HelpModal onClose={() => setShowHelp(false)} numericCriteria={numericCriteria} flagCriteria={flagCriteria} />}
+
+      {showConstraints && (
+        <ConstraintManager
+          students={students}
+          keepApart={keepApart}
+          onAddKeepApart={onAddKeepApart}
+          onRemoveKeepApart={onRemoveKeepApart}
+          keepTogether={keepTogether}
+          onAddKeepTogether={onAddKeepTogether}
+          onRemoveKeepTogether={onRemoveKeepTogether}
+          onClose={() => setShowConstraints(false)}
+        />
+      )}
     </div>
   );
 }

--- a/src/components/OptimizePage.js
+++ b/src/components/OptimizePage.js
@@ -17,6 +17,7 @@ function OptimizePage({
   const [draggingId, setDraggingId] = useState(null);
   const [showHelp, setShowHelp] = useState(false);
   const [showConstraints, setShowConstraints] = useState(false);
+  const [showViolations, setShowViolations] = useState(false);
   const [cost, setCost] = useState(null);
   const [optimizing, setOptimizing] = useState(false);
   const [fullscreen, setFullscreen] = useState(false);
@@ -141,11 +142,26 @@ function OptimizePage({
           </div>
         )}
         {totalViolations > 0 && (
-          <div className="violations-badge" title={`${apartViolations.length} keep-apart, ${togetherViolations.length} keep-together constraint(s) violated`}>
+          <button
+            className="violations-badge"
+            onClick={() => setShowViolations(true)}
+            style={{
+              background: 'transparent',
+              border: 'none',
+              cursor: 'pointer',
+              padding: '4px 8px',
+              borderRadius: 'var(--radius-sm)',
+              display: 'flex',
+              alignItems: 'center',
+              gap: 4,
+            }}
+            title="Click to see violated constraints"
+          >
             <span style={{ color: 'var(--danger)', fontSize: 12, fontWeight: 500 }}>
               ⚠️ {totalViolations} violation{totalViolations === 1 ? '' : 's'}
             </span>
-          </div>
+            <span style={{ fontSize: 10, color: 'var(--text3)' }}>ℹ️</span>
+          </button>
         )}
         <div style={{ marginLeft: 'auto', display: 'flex', gap: 8, alignItems: 'center' }}>
           <div style={{ display: 'flex', gap: 6, alignItems: 'center', borderRight: '1px solid var(--border)', paddingRight: 10, marginRight: 2 }}>
@@ -232,6 +248,210 @@ function OptimizePage({
           onClose={() => setShowConstraints(false)}
         />
       )}
+
+      {showViolations && (
+        <ViolationsModal
+          apartViolations={apartViolations}
+          togetherViolations={togetherViolations}
+          students={students}
+          assignment={assignment}
+          teachers={teachers}
+          onClose={() => setShowViolations(false)}
+          onOpenConstraints={() => {
+            setShowViolations(false);
+            setShowConstraints(true);
+          }}
+        />
+      )}
+    </div>
+  );
+}
+
+// Modal to display constraint violations in detail
+function ViolationsModal({ apartViolations, togetherViolations, students, assignment, teachers, onClose, onOpenConstraints }) {
+  const studentById = Object.fromEntries(students.map(s => [s.id, s]));
+
+  // Get class name for a student
+  function getClassName(studentId) {
+    const classIdx = assignment[studentId];
+    if (classIdx === undefined) return 'Unassigned';
+    return teachers[classIdx]?.name || `Class ${classIdx + 1}`;
+  }
+
+  const hasApart = apartViolations.length > 0;
+  const hasTogether = togetherViolations.length > 0;
+
+  return (
+    <div className="modal-overlay" onClick={onClose}>
+      <div className="modal" onClick={e => e.stopPropagation()} style={{ maxWidth: 600, width: '90%' }}>
+        <div className="modal-header">
+          <h3 style={{ margin: 0 }}>Constraint Violations</h3>
+          <button className="btn btn-ghost btn-sm" onClick={onClose}>✕</button>
+        </div>
+
+        <div className="modal-body" style={{ padding: 20 }}>
+          {/* Explanation */}
+          <div style={{
+            padding: 12,
+            background: 'var(--surface)',
+            borderRadius: 'var(--radius-sm)',
+            marginBottom: 20,
+            fontSize: 13,
+            color: 'var(--text2)',
+            border: '1px solid var(--border)',
+          }}>
+            <strong>Why are constraints violated?</strong>
+            <p style={{ margin: '8px 0 0 0' }}>
+              The optimizer tries to balance all criteria while respecting your constraints. 
+              Sometimes constraints conflict with each other or make class balance impossible. 
+              Consider removing some constraints or manually adjusting the results.
+            </p>
+          </div>
+
+          {/* Keep Apart Violations */}
+          {hasApart && (
+            <div style={{ marginBottom: 24 }}>
+              <h4 style={{
+                margin: '0 0 12px 0',
+                fontSize: 14,
+                fontWeight: 500,
+                color: 'var(--danger)',
+                display: 'flex',
+                alignItems: 'center',
+                gap: 8,
+              }}>
+                <span>🚫</span>
+                Keep-Apart Violations ({apartViolations.length})
+              </h4>
+              <p style={{ margin: '0 0 12px 0', fontSize: 12, color: 'var(--text3)' }}>
+                These students should be in different classes but ended up together:
+              </p>
+              <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+                {apartViolations.map(([id1, id2], idx) => (
+                  <div key={idx} style={{
+                    background: 'var(--bg)',
+                    border: '1px solid var(--border)',
+                    borderRadius: 'var(--radius-sm)',
+                    padding: '10px 12px',
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: 12,
+                    flexWrap: 'wrap',
+                  }}>
+                    <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+                      <span className="badge" style={{ background: 'var(--surface)', color: 'var(--text)' }}>
+                        {studentById[id1]?.name || id1}
+                      </span>
+                      <span style={{ color: 'var(--text3)' }}>↔</span>
+                      <span className="badge" style={{ background: 'var(--surface)', color: 'var(--text)' }}>
+                        {studentById[id2]?.name || id2}
+                      </span>
+                    </div>
+                    <span style={{
+                      marginLeft: 'auto',
+                      fontSize: 11,
+                      color: 'var(--danger)',
+                      fontWeight: 500,
+                    }}>
+                      Both in: {getClassName(id1)}
+                    </span>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* Keep Together Violations */}
+          {hasTogether && (
+            <div style={{ marginBottom: 24 }}>
+              <h4 style={{
+                margin: '0 0 12px 0',
+                fontSize: 14,
+                fontWeight: 500,
+                color: 'var(--danger)',
+                display: 'flex',
+                alignItems: 'center',
+                gap: 8,
+              }}>
+                <span>🔗</span>
+                Keep-Together Violations ({togetherViolations.length})
+              </h4>
+              <p style={{ margin: '0 0 12px 0', fontSize: 12, color: 'var(--text3)' }}>
+                These students should be in the same class but were split up:
+              </p>
+              <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+                {togetherViolations.map((group, idx) => {
+                  const classDistribution = {};
+                  group.forEach(id => {
+                    const className = getClassName(id);
+                    if (!classDistribution[className]) classDistribution[className] = [];
+                    classDistribution[className].push(studentById[id]?.name || id);
+                  });
+
+                  return (
+                    <div key={idx} style={{
+                      background: 'var(--bg)',
+                      border: '1px solid var(--border)',
+                      borderRadius: 'var(--radius-sm)',
+                      padding: '10px 12px',
+                    }}>
+                      <div style={{ marginBottom: 8, fontSize: 12, color: 'var(--text3)' }}>
+                        Group {idx + 1}:
+                      </div>
+                      {Object.entries(classDistribution).map(([className, names]) => (
+                        <div key={className} style={{
+                          display: 'flex',
+                          alignItems: 'center',
+                          gap: 8,
+                          marginBottom: 4,
+                          flexWrap: 'wrap',
+                        }}>
+                          <span style={{
+                            fontSize: 11,
+                            color: 'var(--danger)',
+                            fontWeight: 500,
+                            minWidth: 80,
+                          }}>
+                            {className}:
+                          </span>
+                          <span style={{ fontSize: 13 }}>
+                            {names.join(', ')}
+                          </span>
+                        </div>
+                      ))}
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
+          )}
+
+          {/* Suggestions */}
+          <div style={{
+            padding: 12,
+            background: 'var(--surface)',
+            borderRadius: 'var(--radius-sm)',
+            border: '1px solid var(--border)',
+          }}>
+            <h5 style={{ margin: '0 0 8px 0', fontSize: 13, fontWeight: 500 }}>
+              What can you do?
+            </h5>
+            <ul style={{ margin: 0, paddingLeft: 18, fontSize: 12, color: 'var(--text2)' }}>
+              <li>Click "Edit Constraints" below to remove conflicting constraints</li>
+              <li>Try re-optimizing with fewer constraints</li>
+              <li>Manually drag students to fix violations (locked students stay in place)</li>
+              <li>Consider if some constraints are truly necessary</li>
+            </ul>
+          </div>
+        </div>
+
+        <div className="modal-footer" style={{ justifyContent: 'space-between' }}>
+          <button className="btn btn-secondary" onClick={onClose}>Close</button>
+          <button className="btn btn-primary" onClick={onOpenConstraints}>
+            Edit Constraints
+          </button>
+        </div>
+      </div>
     </div>
   );
 }

--- a/src/components/SetupPage.js
+++ b/src/components/SetupPage.js
@@ -10,6 +10,9 @@ function SetupPage({
   keepApart,
   onAddKeepApart,
   onRemoveKeepApart,
+  keepTogether,
+  onAddKeepTogether,
+  onRemoveKeepTogether,
   onRemoveStudentConstraints,
 }) {
   const [showForm, setShowForm] = useState(false);
@@ -106,7 +109,7 @@ function SetupPage({
                 <button className="btn btn-secondary btn-sm" onClick={() => setShowImport(true)}>⬆ Import CSV</button>
                 <button className="btn btn-secondary btn-sm" onClick={() => setShowSampleDialog(true)}>Sample Data</button>
                 <button className="btn btn-secondary btn-sm" onClick={() => setShowConstraintModal(true)}>
-                  🔗 Constraints {keepApart.length > 0 && `(${keepApart.length})`}
+                  🔗 Constraints {(keepApart.length + keepTogether.length) > 0 && `(${keepApart.length + keepTogether.length})`}
                 </button>
                 <button className="btn btn-primary btn-sm" onClick={() => setShowForm(true)}>+ Add Student</button>
               </div>
@@ -204,10 +207,13 @@ function SetupPage({
       )}
       {showImport && (
         <ImportModal
-          onImport={(ss, importedKeepApart) => {
+          onImport={(ss, importedKeepApart, importedKeepTogether) => {
             setStudents(prev => [...prev, ...ss]);
             if (importedKeepApart && importedKeepApart.length > 0) {
               importedKeepApart.forEach(pair => onAddKeepApart(pair[0], pair[1]));
+            }
+            if (importedKeepTogether && importedKeepTogether.length > 0) {
+              importedKeepTogether.forEach(group => onAddKeepTogether(group));
             }
           }}
           onClose={() => setShowImport(false)}
@@ -221,6 +227,9 @@ function SetupPage({
           keepApart={keepApart}
           onAddKeepApart={onAddKeepApart}
           onRemoveKeepApart={onRemoveKeepApart}
+          keepTogether={keepTogether}
+          onAddKeepTogether={onAddKeepTogether}
+          onRemoveKeepTogether={onRemoveKeepTogether}
           onClose={() => setShowConstraintModal(false)}
         />
       )}

--- a/src/csv.js
+++ b/src/csv.js
@@ -37,7 +37,7 @@ function parseCSV(text, numericCriteria, flagCriteria) {
   // Normalize CRLF and bare CR to LF
   const normalized = text.trim().replace(/\r\n/g, '\n').replace(/\r/g, '\n');
   const lines = normalized.split('\n');
-  if (lines.length < 2) return { students: [], errors: ['No data rows found'], keepApart: [] };
+  if (lines.length < 2) return { students: [], errors: ['No data rows found'], keepApart: [], keepTogether: [] };
 
   // Normalize headers: lowercase, strip spaces
   const headers = parseCSVLine(lines[0]).map(h => h.toLowerCase().replace(/\s+/g, ''));
@@ -45,6 +45,7 @@ function parseCSV(text, numericCriteria, flagCriteria) {
   const students = [];
   const errors = [];
   const keepApartGroups = {}; // groupId -> array of student indices
+  const keepTogetherGroups = {}; // groupId -> array of student indices
 
   // Build mapping from criteria keys to CSV column indices
   const numericKeyMap = {};
@@ -60,10 +61,11 @@ function parseCSV(text, numericCriteria, flagCriteria) {
     if (idx !== -1) flagKeyMap[key] = idx;
   });
 
-  // Find name, gender, and keep_apart_group columns
+  // Find name, gender, and keep constraint columns
   const nameIdx = headers.findIndex(h => ['name','student','lastnamefirstname'].includes(h));
   const genderIdx = headers.findIndex(h => ['gender','sex'].includes(h));
   const keepApartIdx = headers.findIndex(h => h === 'keepapartgroup' || h === 'keep_apart_group');
+  const keepTogetherIdx = headers.findIndex(h => h === 'keeptogethergroup' || h === 'keep_together_group');
 
   if (nameIdx === -1) errors.push('Could not find a name column (expected: name, student)');
   if (genderIdx === -1) errors.push('Could not find a gender column (expected: gender, sex)');
@@ -104,6 +106,15 @@ function parseCSV(text, numericCriteria, flagCriteria) {
       }
     }
 
+    // Track keep together groups
+    if (keepTogetherIdx !== -1) {
+      const groupId = cols[keepTogetherIdx]?.trim();
+      if (groupId) {
+        if (!keepTogetherGroups[groupId]) keepTogetherGroups[groupId] = [];
+        keepTogetherGroups[groupId].push(student.id);
+      }
+    }
+
     students.push(student);
   });
 
@@ -118,49 +129,62 @@ function parseCSV(text, numericCriteria, flagCriteria) {
     }
   });
 
-  return { students, errors, keepApart };
+  // Build keepTogether groups array
+  const keepTogether = Object.values(keepTogetherGroups).filter(group => group.length >= 2);
+
+  return { students, errors, keepApart, keepTogether };
 }
 
-function exportStudentsToCSV(students, numericCriteria, flagCriteria, keepApart = []) {
-  const headers = ['name', 'gender', ...numericCriteria.map(c => c.key), ...flagCriteria.map(c => c.key), 'keep_apart_group'];
+function exportStudentsToCSV(students, numericCriteria, flagCriteria, keepApart = [], keepTogether = []) {
+  const headers = ['name', 'gender', ...numericCriteria.map(c => c.key), ...flagCriteria.map(c => c.key), 'keep_apart_group', 'keep_together_group'];
   const lines = [headers.join(',')];
 
-  // Build a map of student ID to group number
-  const studentGroupMap = new Map();
-  const groupMap = new Map();
-  let nextGroupNum = 1;
+  // Build a map of student ID to keep-apart group number
+  const studentApartMap = new Map();
+  const apartMap = new Map();
+  let nextApartNum = 1;
   keepApart.forEach(([id1, id2]) => {
-    const group1 = studentGroupMap.get(id1);
-    const group2 = studentGroupMap.get(id2);
+    const group1 = studentApartMap.get(id1);
+    const group2 = studentApartMap.get(id2);
     if (group1 && group2 && group1 !== group2) {
       // Merge groups - use the lower number
       const targetGroup = Math.min(group1, group2);
       const sourceGroup = Math.max(group1, group2);
       // Update all students in source group to target group
-      groupMap.get(sourceGroup).forEach(id => studentGroupMap.set(id, targetGroup));
-      groupMap.get(targetGroup).push(...groupMap.get(sourceGroup));
-      groupMap.delete(sourceGroup);
+      apartMap.get(sourceGroup).forEach(id => studentApartMap.set(id, targetGroup));
+      apartMap.get(targetGroup).push(...apartMap.get(sourceGroup));
+      apartMap.delete(sourceGroup);
     } else if (group1) {
-      studentGroupMap.set(id2, group1);
-      groupMap.get(group1).push(id2);
+      studentApartMap.set(id2, group1);
+      apartMap.get(group1).push(id2);
     } else if (group2) {
-      studentGroupMap.set(id1, group2);
-      groupMap.get(group2).push(id1);
+      studentApartMap.set(id1, group2);
+      apartMap.get(group2).push(id1);
     } else {
       // New group
-      studentGroupMap.set(id1, nextGroupNum);
-      studentGroupMap.set(id2, nextGroupNum);
-      groupMap.set(nextGroupNum, [id1, id2]);
-      nextGroupNum++;
+      studentApartMap.set(id1, nextApartNum);
+      studentApartMap.set(id2, nextApartNum);
+      apartMap.set(nextApartNum, [id1, id2]);
+      nextApartNum++;
     }
   });
 
+  // Build a map of student ID to keep-together group number
+  const studentTogetherMap = new Map();
+  let nextTogetherNum = 1;
+  keepTogether.forEach(group => {
+    group.forEach(id => studentTogetherMap.set(id, nextTogetherNum));
+    nextTogetherNum++;
+  });
+
   students.forEach(s => {
-    const groupNum = studentGroupMap.get(s.id);
+    const apartNum = studentApartMap.get(s.id);
+    const togetherNum = studentTogetherMap.get(s.id);
     const values = [s.name, s.gender];
     numericCriteria.forEach(({ key }) => values.push(s[key] || 0));
     flagCriteria.forEach(({ key }) => values.push(s[key] ? 1 : 0));
-    values.push(groupNum || '');
+    values.push(apartNum || '');
+    values.push(togetherNum || '');
     lines.push(values.join(','));
   });
 

--- a/src/optimizer.js
+++ b/src/optimizer.js
@@ -1,4 +1,4 @@
-function computeCost(students, assignment, numClasses, numericCriteria, flagCriteria, keepApart = []) {
+function computeCost(students, assignment, numClasses, numericCriteria, flagCriteria, keepApart = [], keepTogether = []) {
   if (!students.length || !numClasses) return 0;
   const classes = Array.from({ length: numClasses }, () => []);
   students.forEach(s => {
@@ -101,6 +101,20 @@ function computeCost(students, assignment, numClasses, numericCriteria, flagCrit
   }, 0);
   cost += 100.0 * keepApartPenalty;
 
+  // Keep Together penalty: count of groups split across classes (very high weight)
+  // Note: This is a soft constraint - high penalty encourages togetherness but doesn't guarantee it
+  const keepTogetherPenalty = keepTogether.reduce((penalty, group) => {
+    if (group.length < 2) return penalty;
+    const classes = new Set();
+    for (const id of group) {
+      const c = assignment[id];
+      if (c !== undefined) classes.add(c);
+    }
+    // Penalty if group members are in more than 1 class
+    return classes.size > 1 ? penalty + 1 : penalty;
+  }, 0);
+  cost += 200.0 * keepTogetherPenalty;
+
   return cost;
 }
 
@@ -117,7 +131,7 @@ function createSeededRNG(seed) {
 }
 
 // Compute deterministic seed from input data
-function computeSeed(students, numClasses, lockedAssignments, numericCriteria, flagCriteria, keepApart = []) {
+function computeSeed(students, numClasses, lockedAssignments, numericCriteria, flagCriteria, keepApart = [], keepTogether = []) {
   let hash = 2166136261;
   const fnv = (h, v) => Math.imul(h ^ v, 16777619);
 
@@ -147,14 +161,26 @@ function computeSeed(students, numClasses, lockedAssignments, numericCriteria, f
     hash = fnv(hash, pair[1].split('').reduce((h, c) => fnv(h, c.charCodeAt(0)), hash));
   }
 
+  // Hash keepTogether constraints for determinism
+  const sortedKeepTogether = [...keepTogether].map(group => [...group].sort()).sort((a, b) => {
+    if (a[0] !== b[0]) return a[0].localeCompare(b[0]);
+    return a[1]?.localeCompare(b[1]) || 0;
+  });
+  for (const group of sortedKeepTogether) {
+    hash = fnv(hash, group.length);
+    for (const id of group) {
+      hash = fnv(hash, id.split('').reduce((h, c) => fnv(h, c.charCodeAt(0)), hash));
+    }
+  }
+
   return hash >>> 0;
 }
 
-function optimize(students, numClasses, lockedAssignments = {}, numericCriteria, flagCriteria, keepApart = []) {
+function optimize(students, numClasses, lockedAssignments = {}, numericCriteria, flagCriteria, keepApart = [], keepTogether = []) {
   if (!students.length || !numClasses) return {};
   const unlocked = students.filter(s => lockedAssignments[s.id] === undefined);
 
-  const seed = computeSeed(students, numClasses, lockedAssignments, numericCriteria, flagCriteria, keepApart);
+  const seed = computeSeed(students, numClasses, lockedAssignments, numericCriteria, flagCriteria, keepApart, keepTogether);
   const rand = createSeededRNG(seed);
 
   // ── Greedy init: O(n) with running size counters ────────────────
@@ -309,6 +335,21 @@ function optimize(students, numClasses, lockedAssignments = {}, numericCriteria,
       return (c1 !== undefined && c2 !== undefined && c1 === c2) ? penalty + 1 : penalty;
     }, 0);
     cost += 100.0 * keepApartPenalty;
+
+    // Keep Together penalty: count of groups split across classes (very high weight)
+    // Note: This is a soft constraint - high penalty encourages togetherness but doesn't guarantee it
+    const keepTogetherPenalty = keepTogether.reduce((penalty, group) => {
+      if (group.length < 2) return penalty;
+      const classes = new Set();
+      for (const id of group) {
+        const c = assignment[id];
+        if (c !== undefined) classes.add(c);
+      }
+      // Penalty if group members are in more than 1 class
+      return classes.size > 1 ? penalty + 1 : penalty;
+    }, 0);
+    cost += 200.0 * keepTogetherPenalty;
+
     return cost;
   }
 
@@ -390,6 +431,40 @@ function optimize(students, numClasses, lockedAssignments = {}, numericCriteria,
       else if (!wasViolating && isViolating) keepApartDelta += 1;
     }
     delta += 100.0 * keepApartDelta;
+
+    // Keep Together delta: changes if swap splits or joins a group
+    let keepTogetherDelta = 0;
+    for (const group of keepTogether) {
+      if (group.length < 2) continue;
+      // Check if group is affected by this swap
+      const isS1InGroup = group.includes(s1.id);
+      const isS2InGroup = group.includes(s2.id);
+      if (!isS1InGroup && !isS2InGroup) continue; // Group unchanged
+
+      // Calculate old state: are all group members in the same class?
+      const oldClasses = new Set();
+      for (const id of group) {
+        const c = assignment[id];
+        if (c !== undefined) oldClasses.add(c);
+      }
+      const wasSplit = oldClasses.size > 1;
+
+      // Calculate new classes after swap
+      const newClasses = new Set();
+      for (const id of group) {
+        let c = assignment[id];
+        if (id === s1.id) c = c2;
+        else if (id === s2.id) c = c1;
+        if (c !== undefined) newClasses.add(c);
+      }
+      const isSplit = newClasses.size > 1;
+
+      // Delta: +1 if newly split, -1 if newly joined
+      if (!wasSplit && isSplit) keepTogetherDelta += 1;
+      else if (wasSplit && !isSplit) keepTogetherDelta -= 1;
+    }
+    delta += 200.0 * keepTogetherDelta;
+
     // Class sizes don't change in a same-depth swap
     return delta;
   }

--- a/tests/csv.test.js
+++ b/tests/csv.test.js
@@ -308,9 +308,9 @@ Bob,F,`;
 
       // Assert
       const lines = csv.split('\n');
-      expect(lines[0]).toBe('name,gender,readingScore,mathScore,behavior,sped,keep_apart_group');
-      expect(lines[1]).toBe('Alice,F,85,90,1,0,');
-      expect(lines[2]).toBe('Bob,M,78,82,0,1,');
+      expect(lines[0]).toBe('name,gender,readingScore,mathScore,behavior,sped,keep_apart_group,keep_together_group');
+      expect(lines[1]).toBe('Alice,F,85,90,1,0,,');
+      expect(lines[2]).toBe('Bob,M,78,82,0,1,,');
     });
 
     test('handles students with missing fields', () => {
@@ -324,7 +324,7 @@ Bob,F,`;
 
       // Assert
       const lines = csv.split('\n');
-      expect(lines[1]).toBe('Alice,F,0,0,0,0,');
+      expect(lines[1]).toBe('Alice,F,0,0,0,0,,');
     });
 
     test('exports empty student list with headers only', () => {
@@ -337,7 +337,7 @@ Bob,F,`;
       // Assert
       const lines = csv.split('\n');
       expect(lines).toHaveLength(1);
-      expect(lines[0]).toBe('name,gender,readingScore,mathScore,behavior,sped,keep_apart_group');
+      expect(lines[0]).toBe('name,gender,readingScore,mathScore,behavior,sped,keep_apart_group,keep_together_group');
     });
 
     test('exports keep apart groups to CSV', () => {
@@ -354,11 +354,11 @@ Bob,F,`;
 
       // Assert
       const lines = csv.split('\n');
-      expect(lines[0]).toBe('name,gender,readingScore,mathScore,behavior,sped,keep_apart_group');
+      expect(lines[0]).toBe('name,gender,readingScore,mathScore,behavior,sped,keep_apart_group,keep_together_group');
       // All three should have group 1
-      expect(lines[1]).toBe('Alice,F,85,90,0,0,1');
-      expect(lines[2]).toBe('Bob,M,78,82,0,0,1');
-      expect(lines[3]).toBe('Charlie,M,70,75,0,0,1');
+      expect(lines[1]).toBe('Alice,F,85,90,0,0,1,');
+      expect(lines[2]).toBe('Bob,M,78,82,0,0,1,');
+      expect(lines[3]).toBe('Charlie,M,70,75,0,0,1,');
     });
 
     test('exports multiple keep apart groups', () => {
@@ -376,10 +376,10 @@ Bob,F,`;
 
       // Assert
       const lines = csv.split('\n');
-      expect(lines[1]).toBe('Alice,F,85,90,0,0,1');
-      expect(lines[2]).toBe('Bob,M,78,82,0,0,1');
-      expect(lines[3]).toBe('Charlie,M,70,75,0,0,2');
-      expect(lines[4]).toBe('Diana,F,92,88,0,0,2');
+      expect(lines[1]).toBe('Alice,F,85,90,0,0,1,');
+      expect(lines[2]).toBe('Bob,M,78,82,0,0,1,');
+      expect(lines[3]).toBe('Charlie,M,70,75,0,0,2,');
+      expect(lines[4]).toBe('Diana,F,92,88,0,0,2,');
     });
   });
 
@@ -596,6 +596,160 @@ Charlie,M,70,1`;
 
       // Assert
       expect(result.keepApart).toHaveLength(3);
+    });
+  });
+
+  describe('keep_together_group parsing', () => {
+    test('parses keep_together_group column', () => {
+      // Arrange
+      const csv = `name,gender,readingScore,keep_together_group
+Alice,F,85,1
+Bob,M,78,1
+Charlie,M,70,2
+Diana,F,92,2`;
+
+      // Act
+      const result = parseCSV(csv, [{ key: 'readingScore' }], []);
+
+      // Assert
+      expect(result.students).toHaveLength(4);
+      expect(result.keepTogether).toHaveLength(2); // Two groups
+      // Should create groups: [Alice, Bob] and [Charlie, Diana]
+      const studentIds = result.students.map(s => s.id);
+      expect(result.keepTogether).toContainEqual([studentIds[0], studentIds[1]]);
+      expect(result.keepTogether).toContainEqual([studentIds[2], studentIds[3]]);
+    });
+
+    test('parses keeptogethergroup (no underscore) column', () => {
+      // Arrange
+      const csv = `name,gender,readingScore,keeptogethergroup
+Alice,F,85,groupA
+Bob,M,78,groupA`;
+
+      // Act
+      const result = parseCSV(csv, [{ key: 'readingScore' }], []);
+
+      // Assert
+      expect(result.students).toHaveLength(2);
+      expect(result.keepTogether).toHaveLength(1);
+    });
+
+    test('handles empty keep_together_group values', () => {
+      // Arrange
+      const csv = `name,gender,readingScore,keep_together_group
+Alice,F,85,
+Bob,M,78,1
+Charlie,M,70,`;
+
+      // Act
+      const result = parseCSV(csv, [{ key: 'readingScore' }], []);
+
+      // Assert
+      expect(result.students).toHaveLength(3);
+      expect(result.keepTogether).toHaveLength(0); // Only one student in group 1
+    });
+
+    test('handles missing keep_together_group column', () => {
+      // Arrange
+      const csv = `name,gender,readingScore
+Alice,F,85
+Bob,M,78`;
+
+      // Act
+      const result = parseCSV(csv, [{ key: 'readingScore' }], []);
+
+      // Assert
+      expect(result.students).toHaveLength(2);
+      expect(result.keepTogether).toEqual([]);
+    });
+
+    test('creates groups of size 3 correctly', () => {
+      // Arrange - group of 3
+      const csv = `name,gender,readingScore,keep_together_group
+Alice,F,85,1
+Bob,M,78,1
+Charlie,M,70,1`;
+
+      // Act
+      const result = parseCSV(csv, [{ key: 'readingScore' }], []);
+
+      // Assert
+      expect(result.keepTogether).toHaveLength(1);
+      expect(result.keepTogether[0]).toHaveLength(3);
+    });
+  });
+
+  describe('keep_together_group export', () => {
+    test('exports keep together groups to CSV', () => {
+      // Arrange
+      const students = [
+        { id: 's1', name: 'Alice', gender: 'F', readingScore: 85, mathScore: 90, behavior: false, sped: false },
+        { id: 's2', name: 'Bob', gender: 'M', readingScore: 78, mathScore: 82, behavior: false, sped: false },
+        { id: 's3', name: 'Charlie', gender: 'M', readingScore: 70, mathScore: 75, behavior: false, sped: false },
+      ];
+      const keepTogether = [['s1', 's2']]; // Alice and Bob should be kept together
+
+      // Act
+      const csv = exportStudentsToCSV(students, numericCriteria, flagCriteria, [], keepTogether);
+
+      // Assert
+      const lines = csv.split('\n');
+      expect(lines[0]).toBe('name,gender,readingScore,mathScore,behavior,sped,keep_apart_group,keep_together_group');
+      // Alice and Bob should have group 1, Charlie should have no group
+      expect(lines[1]).toBe('Alice,F,85,90,0,0,,1');
+      expect(lines[2]).toBe('Bob,M,78,82,0,0,,1');
+      expect(lines[3]).toBe('Charlie,M,70,75,0,0,,');
+    });
+
+    test('exports multiple keep together groups', () => {
+      // Arrange
+      const students = [
+        { id: 's1', name: 'Alice', gender: 'F', readingScore: 85, mathScore: 90, behavior: false, sped: false },
+        { id: 's2', name: 'Bob', gender: 'M', readingScore: 78, mathScore: 82, behavior: false, sped: false },
+        { id: 's3', name: 'Charlie', gender: 'M', readingScore: 70, mathScore: 75, behavior: false, sped: false },
+        { id: 's4', name: 'Diana', gender: 'F', readingScore: 92, mathScore: 88, behavior: false, sped: false },
+      ];
+      const keepTogether = [['s1', 's2'], ['s3', 's4']]; // Two separate groups
+
+      // Act
+      const csv = exportStudentsToCSV(students, numericCriteria, flagCriteria, [], keepTogether);
+
+      // Assert
+      const lines = csv.split('\n');
+      expect(lines[1]).toBe('Alice,F,85,90,0,0,,1');
+      expect(lines[2]).toBe('Bob,M,78,82,0,0,,1');
+      expect(lines[3]).toBe('Charlie,M,70,75,0,0,,2');
+      expect(lines[4]).toBe('Diana,F,92,88,0,0,,2');
+    });
+  });
+
+  describe('Combined constraints round-trip', () => {
+    test('round-trip preserves both constraint types', () => {
+      // Arrange
+      const students = [
+        { id: 's1', name: 'Alice', gender: 'F', readingScore: 85 },
+        { id: 's2', name: 'Bob', gender: 'M', readingScore: 78 },
+        { id: 's3', name: 'Charlie', gender: 'M', readingScore: 70 },
+        { id: 's4', name: 'Diana', gender: 'F', readingScore: 92 },
+      ];
+      const keepApart = [['s1', 's3']]; // Alice and Charlie apart
+      const keepTogether = [['s1', 's2']]; // Alice and Bob together
+
+      // Act - export then parse
+      const csv = exportStudentsToCSV(students, [{ key: 'readingScore' }], [], keepApart, keepTogether);
+      const result = parseCSV(csv, [{ key: 'readingScore' }], []);
+
+      // Assert - students reconstructed
+      expect(result.students).toHaveLength(4);
+
+      // Check keepApart - Alice and Charlie should be apart
+      const studentNames = result.students.reduce((acc, s) => ({ ...acc, [s.id]: s.name }), {});
+      const apartNames = result.keepApart.map(pair => [studentNames[pair[0]], studentNames[pair[1]]].sort());
+      expect(apartNames).toContainEqual(['Alice', 'Charlie']);
+
+      // Check keepTogether - Alice and Bob should be together
+      const togetherNames = result.keepTogether.map(group => group.map(id => studentNames[id]).sort());
+      expect(togetherNames).toContainEqual(['Alice', 'Bob']);
     });
   });
 });

--- a/tests/optimizer.test.js
+++ b/tests/optimizer.test.js
@@ -553,4 +553,175 @@ describe('Optimizer', () => {
       expect(assignmentWithConstraint).toEqual(assignmentWithoutConstraint);
     });
   });
+
+  describe('Keep Together Constraints', () => {
+    test('keep together constraint encourages students to be in same class', () => {
+      // Arrange - small class count so togetherness is easier to achieve
+      const students = createMockStudents(6);
+      const numClasses = 2;
+      // Force two students to be kept together
+      const keepTogether = [[students[0].id, students[1].id]];
+
+      // Act
+      const assignment = optimize(students, numClasses, {}, numericCriteria, flagCriteria, [], keepTogether);
+
+      // Assert - with high penalty weight, optimizer should usually keep them together
+      // Note: This is a soft constraint, not a guarantee
+      const cost = computeCost(students, assignment, numClasses, numericCriteria, flagCriteria, [], keepTogether);
+
+      // The cost should be reasonably low, indicating the optimizer tried to respect the constraint
+      expect(cost).toBeLessThan(500); // Very high cost would indicate ignoring the constraint
+    });
+
+    test('cost includes penalty for keep-together violations', () => {
+      // Arrange
+      const students = createMockStudents(4);
+      const numClasses = 2;
+      const keepTogether = [[students[0].id, students[1].id]];
+
+      // Create an assignment with violation
+      const violatingAssignment = {
+        [students[0].id]: 0,
+        [students[1].id]: 1, // Different class - violation!
+        [students[2].id]: 0,
+        [students[3].id]: 1,
+      };
+
+      // Create an assignment without violation
+      const validAssignment = {
+        [students[0].id]: 0,
+        [students[1].id]: 0, // Same class - no violation
+        [students[2].id]: 1,
+        [students[3].id]: 1,
+      };
+
+      // Act
+      const violatingCost = computeCost(students, violatingAssignment, numClasses, numericCriteria, flagCriteria, [], keepTogether);
+      const validCost = computeCost(students, validAssignment, numClasses, numericCriteria, flagCriteria, [], keepTogether);
+
+      // Assert - violating cost should be higher by approximately 200 (penalty weight)
+      expect(violatingCost).toBeGreaterThan(validCost + 190);
+    });
+
+    test('determinism holds with keep together constraints', () => {
+      // Arrange
+      const students = createMockStudents(6);
+      const numClasses = 2;
+      const keepTogether = [[students[0].id, students[1].id], [students[2].id, students[3].id]];
+
+      // Act - run twice with same inputs
+      const assignment1 = optimize(students, numClasses, {}, numericCriteria, flagCriteria, [], keepTogether);
+      const assignment2 = optimize(students, numClasses, {}, numericCriteria, flagCriteria, [], keepTogether);
+
+      // Assert - should be identical
+      expect(assignment1).toEqual(assignment2);
+    });
+
+    test('computeSeed includes keep together constraints', () => {
+      // Arrange
+      const students = createMockStudents(4);
+      const numClasses = 2;
+      const keepTogether1 = [[students[0].id, students[1].id]];
+      const keepTogether2 = [[students[0].id, students[2].id]]; // Different constraint
+
+      // Act
+      const seed1 = computeSeed(students, numClasses, {}, numericCriteria, flagCriteria, [], keepTogether1);
+      const seed2 = computeSeed(students, numClasses, {}, numericCriteria, flagCriteria, [], keepTogether2);
+
+      // Assert - different constraints should produce different seeds
+      expect(seed1).not.toBe(seed2);
+    });
+
+    test('same keep together constraints produce same seed', () => {
+      // Arrange
+      const students = createMockStudents(4);
+      const numClasses = 2;
+      const keepTogether = [[students[0].id, students[1].id]];
+
+      // Act
+      const seed1 = computeSeed(students, numClasses, {}, numericCriteria, flagCriteria, [], keepTogether);
+      const seed2 = computeSeed(students, numClasses, {}, numericCriteria, flagCriteria, [], keepTogether);
+
+      // Assert - same constraints should produce same seed
+      expect(seed1).toBe(seed2);
+    });
+
+    test('multiple keep together groups are respected', () => {
+      // Arrange
+      const students = createMockStudents(8);
+      const numClasses = 4;
+      const keepTogether = [
+        [students[0].id, students[1].id],
+        [students[2].id, students[3].id],
+      ];
+
+      // Act
+      const assignment = optimize(students, numClasses, {}, numericCriteria, flagCriteria, [], keepTogether);
+
+      // Assert - check all groups are together
+      expect(assignment[students[0].id]).toBe(assignment[students[1].id]);
+      expect(assignment[students[2].id]).toBe(assignment[students[3].id]);
+    });
+
+    test('empty keep together array works normally', () => {
+      // Arrange
+      const students = createMockStudents(6);
+      const numClasses = 2;
+
+      // Act
+      const assignmentWithConstraint = optimize(students, numClasses, {}, numericCriteria, flagCriteria, [], []);
+      const assignmentWithoutConstraint = optimize(students, numClasses, {}, numericCriteria, flagCriteria, []);
+
+      // Assert - should produce same results
+      expect(assignmentWithConstraint).toEqual(assignmentWithoutConstraint);
+    });
+
+    test('group of size 1 is ignored', () => {
+      // Arrange
+      const students = createMockStudents(4);
+      const numClasses = 2;
+      const keepTogether = [[students[0].id]]; // Single student group
+
+      // Act
+      const assignment = optimize(students, numClasses, {}, numericCriteria, flagCriteria, [], keepTogether);
+
+      // Assert - should work normally
+      students.forEach(s => {
+        expect(assignment[s.id]).toBeDefined();
+      });
+    });
+  });
+
+  describe('Combined Constraints', () => {
+    test('keep apart and keep together work together', () => {
+      // Arrange
+      const students = createMockStudents(8);
+      const numClasses = 2;
+      const keepApart = [[students[0].id, students[2].id]];
+      const keepTogether = [[students[0].id, students[1].id]];
+
+      // Act
+      const assignment = optimize(students, numClasses, {}, numericCriteria, flagCriteria, keepApart, keepTogether);
+
+      // Assert - students 0 and 1 should be together
+      expect(assignment[students[0].id]).toBe(assignment[students[1].id]);
+      // student 0 and 2 should be apart
+      expect(assignment[students[0].id]).not.toBe(assignment[students[2].id]);
+    });
+
+    test('determinism holds with both constraint types', () => {
+      // Arrange
+      const students = createMockStudents(8);
+      const numClasses = 2;
+      const keepApart = [[students[0].id, students[2].id]];
+      const keepTogether = [[students[0].id, students[1].id]];
+
+      // Act
+      const assignment1 = optimize(students, numClasses, {}, numericCriteria, flagCriteria, keepApart, keepTogether);
+      const assignment2 = optimize(students, numClasses, {}, numericCriteria, flagCriteria, keepApart, keepTogether);
+
+      // Assert - should be identical
+      expect(assignment1).toEqual(assignment2);
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Add support for keep-together constraints alongside existing keep-apart constraints, with clear feedback when constraints can't be satisfied.

## What's New

- **Keep Together constraints:** Keep specific students in the same class (siblings, support pairs)
- **Keep Apart constraints:** Already implemented in keep-apart branch - kept together here
- **Violations modal:** Click the ⚠️ violations badge to see which constraints weren't satisfied and why
- **CSV support:** Import/export both constraint types using `keep_apart_group` and `keep_together_group` columns

## How It Works

Constraints are treated as high-priority soft constraints (not absolute rules). The optimizer uses a 200.0 weight penalty for keep-together violations and 100.0 for keep-apart. When constraints conflict with each other or with balance criteria, the ⚠️ badge shows how many couldn't be satisfied.

## Testing

- 85 tests passing (includes 19 new tests for constraints)
- Determinism verified for combined constraint scenarios
- CSV round-trip tested for both constraint types

## Implementation

- `src/optimizer.js` — penalty calculation, seed hashing, swap delta
- `src/components/ConstraintManager.js` — tabbed UI for managing both constraint types
- `src/components/OptimizePage.js` — violations calculation and ViolationsModal
- `src/app.js` — state management for keepTogether
- `src/csv.js` — CSV import/export for constraint columns
- README updated with streamlined documentation

---

Closes #15