### PR TITLE
Fix CSP injection syntax in pages workflow

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -43,7 +43,8 @@ jobs:
         run: |
           # Add Content Security Policy to prevent any network calls
           # This enforces the client-side-only guarantee for the hosted version
-          sed -i 's|<head>|<head>\n  <meta http-equiv="Content-Security-Policy" content="default-src \'self\' \'unsafe-inline\' data:; connect-src \'none\'; img-src \'self\' data:; font-src \'self\' data:;">|' dist/index.html
+          CSP_META='<meta http-equiv="Content-Security-Policy" content="default-src '\''self'\'' '\''unsafe-inline'\'' data:; connect-src '\''none'\''; img-src '\''self'\'' data:; font-src '\''self'\'' data:;">'
+          sed -i "s|<head>|<head>\n  $CSP_META|" dist/index.html
           echo "Injected CSP header for security"
 
       - name: Upload to Pages

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "class-list-optimizer",
-  "version": "1.5.3",
+  "version": "1.5.4",
   "description": "A tool for optimizing class list distributions",
   "scripts": {
     "build": "node build-standalone.js",

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -1,7 +1,7 @@
 const { useState, useEffect, useRef, useCallback, useMemo } = React;
 
 // App version for save/load compatibility checking
-const APP_VERSION = "1.5.3";
+const APP_VERSION = "1.5.4";
 
 const DEFAULT_NUMERIC_CRITERIA = [
   { key: 'readingScore', label: 'Reading Score', short: 'Read', weight: 1.0 },


### PR DESCRIPTION
Fixes the unescaped quote error in the GitHub Pages workflow.

**Error:**
```
/home/runner/work/_temp/...sh: line 4: unexpected EOF while looking for matching `"'
```

**Fix:**
- Moved CSP meta tag to a variable with proper quote escaping
- Uses double quotes for sed to avoid shell interpretation issues

**Version:** Bumped to 1.5.4