### PR TITLE
Welcome modal always shows + v1.5.6 with 5 classes default

### DIFF
--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -696,7 +696,7 @@ Diff the inlined script against the concatenated `src/*.js` files at the tagged 
 | Field | Value |
 |-------|-------|
 | **Document Version** | 1.1 |
-| **Application Version** | 1.5.5 |
+| **Application Version** | 1.5.6 |
 | **Last Updated** | April 28, 2026 |
 | **Review Cycle** | Annual or on major release |
 | **Author** | Class List Optimizer Development Team |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "class-list-optimizer",
-  "version": "1.5.5",
+  "version": "1.5.6",
   "description": "A tool for optimizing class list distributions",
   "scripts": {
     "build": "node build-standalone.js",

--- a/src/app.js
+++ b/src/app.js
@@ -167,7 +167,7 @@ function AppContent() {
         onClose={() => setShowWelcome(false)}
         onLoadDemo={() => {
           // Load demo data with default sample students
-          const demoStudents = generateSampleStudents(27, numericCriteria, flagCriteria);
+          const demoStudents = generateSampleStudents(100, numericCriteria, flagCriteria);
           setStudents(demoStudents);
           setShowWelcome(false);
         }}

--- a/src/components/SetupPage.js
+++ b/src/components/SetupPage.js
@@ -26,7 +26,7 @@ function SetupPage({ onOptimize }) {
   const [showImport, setShowImport] = useState(false);
   const [showSampleDialog, setShowSampleDialog] = useState(false);
   const [showConstraintModal, setShowConstraintModal] = useState(false);
-  const [sampleCount, setSampleCount] = useState(27);
+  const [sampleCount, setSampleCount] = useState(100);
   const [numTeachers, setNumTeachers] = useState(String(teachers.length || 3));
   const [idFilter, setIdFilter] = useState('');
   const [nameFilter, setNameFilter] = useState('');

--- a/src/components/WelcomeModal.js
+++ b/src/components/WelcomeModal.js
@@ -18,25 +18,19 @@ function WelcomeModal({ onClose, onLoadDemo, forceShow = false }) {
     // Check if we're on GitHub Pages
     const isGitHubPages = window.location.hostname.includes('github.io');
 
-    // Check if user has already seen the welcome modal
-    const hasSeenWelcome = localStorage.getItem('welcomeModalSeen');
-
-    // Check for URL parameter to force show (for local testing)
+    // Check for URL parameter to skip welcome (for power users)
     const urlParams = new URLSearchParams(window.location.search);
-    const forceWelcome = urlParams.get('welcome') === '1';
+    const skipWelcome = urlParams.get('skipwelcome') === '1';
 
-    // Show modal if:
-    // 1. We're on GitHub Pages AND user hasn't seen it, OR
-    // 2. Force show prop is enabled (for testing), OR
-    // 3. URL parameter welcome=1 is set (for local testing)
-    if ((isGitHubPages && !hasSeenWelcome) || forceShow || forceWelcome) {
+    // Always show modal on GitHub Pages unless:
+    // 1. skipwelcome=1 URL parameter is set
+    // 2. forceShow prop is explicitly false
+    if (isGitHubPages && !skipWelcome && forceShow !== false) {
       setIsVisible(true);
     }
   }, [forceShow]);
 
   const handleClose = (loadDemo = false) => {
-    // Mark as seen in localStorage
-    localStorage.setItem('welcomeModalSeen', 'true');
     setIsVisible(false);
     if (loadDemo && onLoadDemo) {
       onLoadDemo();

--- a/src/contexts/index.js
+++ b/src/contexts/index.js
@@ -385,6 +385,8 @@
       { id: 'T1', name: 'Class A' },
       { id: 'T2', name: 'Class B' },
       { id: 'T3', name: 'Class C' },
+      { id: 'T4', name: 'Class D' },
+      { id: 'T5', name: 'Class E' },
     ]);
 
     const navigateToOptimize = useCallback(() => setView('optimize'), []);

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -1,7 +1,7 @@
 const { useState, useEffect, useRef, useCallback, useMemo } = React;
 
 // App version for save/load compatibility checking
-const APP_VERSION = "1.5.5";
+const APP_VERSION = "1.5.6";
 
 const DEFAULT_NUMERIC_CRITERIA = [
   { key: 'readingScore', label: 'Reading Score', short: 'Read', weight: 1.0 },


### PR DESCRIPTION
## Changes in v1.5.6

### Welcome Modal Now Always Displays
- Removed "seen once" logic - the modal now shows on EVERY visit to GitHub Pages
- Added `?skipwelcome=1` URL parameter for power users who want to bypass it
- Removed localStorage tracking of dismissal
- Rationale: Users need to see privacy info every time. If they don't want a splash, they can download the file.

### Default Configuration
- **Classes**: Changed from 3 to 5 (Class A, B, C, D, E)
- **Demo students**: Changed from 27 to 100 students
- Makes the demo more realistic for actual school use

### Documentation Cleanup
- Applied avoid-ai-writing principles to README and WelcomeModal
- More direct, less promotional language
- Reduced em dash overuse and chatbot artifacts

## Version
1.5.5 → **1.5.6** (tiny bump)

## Files Changed
- `src/components/WelcomeModal.js` - Always show logic
- `src/contexts/index.js` - 5 default classes
- `src/app.js` - 100 demo students
- `src/components/SetupPage.js` - 100 default sample count
- `README.md` - Humanized language
- `package.json`, `src/defaults.js`, `docs/SECURITY.md` - Version bump

Closes #38