### PR TITLE
Fix: Welcome modal should only show on GitHub Pages

### DIFF
--- a/src/components/WelcomeModal.js
+++ b/src/components/WelcomeModal.js
@@ -11,21 +11,18 @@
  * @param {Function} props.onLoadDemo - Callback to load demo/sample data
  * @param {boolean} [props.forceShow=false] - Force display regardless of domain/localStorage (for testing)
  */
-function WelcomeModal({ onClose, onLoadDemo, forceShow = false }) {
+function WelcomeModal({ onClose, onLoadDemo, forceShow = true }) {
   const [isVisible, setIsVisible] = React.useState(false);
 
   React.useEffect(() => {
-    // Check if we're on GitHub Pages
-    const isGitHubPages = window.location.hostname.includes('github.io');
-
     // Check for URL parameter to skip welcome (for power users)
     const urlParams = new URLSearchParams(window.location.search);
     const skipWelcome = urlParams.get('skipwelcome') === '1';
 
-    // Always show modal on GitHub Pages unless:
+    // Always show modal unless:
     // 1. skipwelcome=1 URL parameter is set
     // 2. forceShow prop is explicitly false
-    if (isGitHubPages && !skipWelcome && forceShow !== false) {
+    if (!skipWelcome && forceShow !== false) {
       setIsVisible(true);
     }
   }, [forceShow]);

--- a/src/components/WelcomeModal.js
+++ b/src/components/WelcomeModal.js
@@ -15,14 +15,17 @@ function WelcomeModal({ onClose, onLoadDemo, forceShow = true }) {
   const [isVisible, setIsVisible] = React.useState(false);
 
   React.useEffect(() => {
+    // Only show on GitHub Pages
+    const isGitHubPages = window.location.hostname.includes('github.io');
+
     // Check for URL parameter to skip welcome (for power users)
     const urlParams = new URLSearchParams(window.location.search);
     const skipWelcome = urlParams.get('skipwelcome') === '1';
 
-    // Always show modal unless:
+    // Only show modal on GitHub Pages unless:
     // 1. skipwelcome=1 URL parameter is set
     // 2. forceShow prop is explicitly false
-    if (!skipWelcome && forceShow !== false) {
+    if (isGitHubPages && !skipWelcome && forceShow !== false) {
       setIsVisible(true);
     }
   }, [forceShow]);


### PR DESCRIPTION
## Problem
The welcome modal was showing for downloaded HTML files and local development, not just GitHub Pages visitors.

## Solution
Restore the `github.io` hostname check so the modal only appears for GitHub Pages hosted version.

## Changes
- Add back `isGitHubPages` hostname check
- Modal only shows on `github.io` domains
- Still respects `?skipwelcome=1` bypass parameter
- Downloaded files and local dev won't see the modal

## Why
The welcome modal was designed specifically for GitHub Pages visitors who need the privacy intro. Downloaded files don't need the splash since users intentionally downloaded them.