### PR TITLE
fix: update remaining display text references to Class List Builder

### DIFF
--- a/class-list-builder-source.html
+++ b/class-list-builder-source.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>Class List Optimizer</title>
+<title>Class List Builder</title>
 <link href="https://fonts.googleapis.com/css2?family=DM+Sans:opsz,wght@9..40,300;9..40,400;9..40,500;9..40,600&family=DM+Mono:wght@400;500&display=swap" rel="stylesheet">
 <link rel="stylesheet" href="src/styles.css">
 <script src="https://unpkg.com/react@18.3.1/umd/react.production.min.js" crossorigin="anonymous"></script>

--- a/src/app.js
+++ b/src/app.js
@@ -222,7 +222,7 @@ function Header({ onNavigateSetup, onNavigateOptimize, onOpenSettings, onOpenSav
   return (
     <header className="app-header">
       <div className="app-logo">
-        Class<span>List</span> Optimizer
+        Class<span>List</span> Builder
       </div>
       <div className="header-steps">
         <button

--- a/src/utils/projectSerializer.js
+++ b/src/utils/projectSerializer.js
@@ -24,7 +24,7 @@ function serializeProject(state) {
       appVersion,
       formatVersion: PROJECT_FORMAT_VERSION,
       exportedAt: new Date().toISOString(),
-      description: 'Class List Optimizer Project File'
+      description: 'Class List Builder Project File'
     },
     data: {
       students: state.students || [],


### PR DESCRIPTION
This PR updates the remaining display text references that were missed in the initial rename from 'Class List Optimizer' to 'Class List Builder'.

## Changes
- **class-list-builder-source.html**: Update page title from 'Class List Optimizer' to 'Class List Builder'
- **src/app.js**: Update header logo text from 'Class List Optimizer' to 'Class List Builder'
- **src/utils/projectSerializer.js**: Update project file description from 'Class List Optimizer Project File' to 'Class List Builder Project File'

## Note
Version is already at 1.7.1 from the previous rename PR #52.