### PR TITLE
Fix settings changes not triggering re-optimization

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "class-list-builder",
-  "version": "1.7.2",
+  "version": "1.7.3",
   "description": "A tool for optimizing class list distributions",
   "scripts": {
     "build": "node build-standalone.js",

--- a/src/components/OptimizePage.js
+++ b/src/components/OptimizePage.js
@@ -91,6 +91,13 @@ function OptimizePage({ onBack }) {
     runOptimize(lockedObj);
   }
 
+  // Auto-reoptimize when criteria change (respecting locked students)
+  useEffect(() => {
+    if (assignment && Object.keys(assignment).length > 0 && !optimizing) {
+      handleReoptimize();
+    }
+  }, [numericCriteria, flagCriteria]);
+
   function handleToggleLock(sid) {
     setLocked(prev => {
       const next = new Set(prev);

--- a/src/components/OptimizePage.js
+++ b/src/components/OptimizePage.js
@@ -57,7 +57,7 @@ function OptimizePage({ onBack }) {
 
   const numClasses = teachers.length;
 
-  function runOptimize(lockedAssignments) {
+  const runOptimize = useCallback((lockedAssignments) => {
     setOptimizing(true);
     setTimeout(() => {
       const lockedObj = {};
@@ -67,14 +67,21 @@ function OptimizePage({ onBack }) {
       setCost(computeCost(students, result, numClasses, numericCriteria, flagCriteria, keepApart, keepTogether, keepOutOfClass));
       setOptimizing(false);
     }, 30);
-  }
+  }, [students, numClasses, numericCriteria, flagCriteria, keepApart, keepTogether, keepOutOfClass, setAssignment]);
 
   useEffect(() => {
     // Only run initial optimization if we don't have an assignment yet
     if (!assignment || Object.keys(assignment).length === 0) {
       runOptimize(new Map());
     }
-  }, []);
+  }, [assignment, runOptimize]);
+
+  // Recompute cost when criteria change (to reflect new weights in display)
+  useEffect(() => {
+    if (assignment && Object.keys(assignment).length > 0) {
+      setCost(computeCost(students, assignment, numClasses, numericCriteria, flagCriteria, keepApart, keepTogether, keepOutOfClass));
+    }
+  }, [numericCriteria, flagCriteria, students, assignment, numClasses, keepApart, keepTogether, keepOutOfClass]);
 
   function handleReoptimize() {
     const lockedObj = new Map();

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -1,7 +1,7 @@
 const { useState, useEffect, useRef, useCallback, useMemo } = React;
 
 // App version for save/load compatibility checking
-const APP_VERSION = "1.7.2";
+const APP_VERSION = "1.7.3";
 
 const DEFAULT_NUMERIC_CRITERIA = [
   { key: 'readingScore', label: 'Reading Score', short: 'Read', weight: 1.0 },

--- a/src/optimizer.js
+++ b/src/optimizer.js
@@ -180,9 +180,15 @@ function computeSeed(students, numClasses, lockedAssignments, numericCriteria, f
   const sortedStudents = [...students].sort((a, b) => a.id.localeCompare(b.id));
   for (const s of sortedStudents) {
     hash = fnv(hash, s.id.split('').reduce((h, c) => fnv(h, c.charCodeAt(0)), hash));
-    numericCriteria.forEach(({ key }) => hash = fnv(hash, Math.floor(s[key] || 0)));
+    numericCriteria.forEach(({ key, weight }) => {
+      hash = fnv(hash, Math.floor(s[key] || 0));
+      hash = fnv(hash, Math.floor((weight || 1) * 1000)); // Include weight in seed
+    });
     hash = fnv(hash, s.gender === 'F' ? 1 : s.gender === 'M' ? 2 : 3);
-    flagCriteria.forEach(({ key }) => hash = fnv(hash, s[key] ? 1 : 0));
+    flagCriteria.forEach(({ key, weight }) => {
+      hash = fnv(hash, s[key] ? 1 : 0);
+      hash = fnv(hash, Math.floor((weight || 1) * 1000)); // Include weight in seed
+    });
   }
 
   const lockedIds = Object.keys(lockedAssignments).sort();

--- a/tests/settings-optimization.test.js
+++ b/tests/settings-optimization.test.js
@@ -1,0 +1,300 @@
+import { describe, test, expect, beforeEach, vi } from 'vitest';
+import { optimize, computeCost, computeSeed } from '../src/optimizer.js';
+
+/**
+ * Test suite for settings changes affecting optimization
+ * 
+ * This test verifies that changing criteria weights (in SettingsModal)
+ * properly triggers re-optimization with the new weights.
+ * 
+ * Bug: When users changed flag/numeric weights after optimizing,
+ * the optimization results would not update because:
+ * 1. The RNG seed didn't include weights (now fixed)
+ * 2. Auto-reoptimization wasn't triggered when criteria changed (now fixed)
+ */
+
+describe('Settings Changes - Optimization Updates', () => {
+  let students;
+  let baseNumericCriteria;
+  let baseFlagCriteria;
+
+  beforeEach(() => {
+    // Create test students with varied attributes - larger dataset for meaningful tests
+    students = [];
+    for (let i = 0; i < 30; i++) {
+      students.push({
+        id: `s${i}`,
+        name: `Student ${i}`,
+        gender: i % 2 === 0 ? 'F' : 'M',
+        readingScore: 50 + (i * 3) % 50,
+        mathScore: 40 + (i * 7) % 50,
+        behavior: i % 3 === 0,
+      });
+    }
+
+    baseNumericCriteria = [
+      { key: 'readingScore', label: 'Reading', weight: 1.0 },
+      { key: 'mathScore', label: 'Math', weight: 1.0 },
+    ];
+
+    baseFlagCriteria = [
+      { key: 'behavior', label: 'Behavior', weight: 1.0 },
+    ];
+  });
+
+  test('changing numeric criteria weights produces different optimization results', () => {
+    const numClasses = 3;
+    const lockedAssignments = {};
+
+    // First optimization with base weights
+    const result1 = optimize(
+      students,
+      numClasses,
+      lockedAssignments,
+      baseNumericCriteria,
+      baseFlagCriteria,
+      [],
+      [],
+      []
+    );
+
+    // Change weights - emphasize reading score more
+    const modifiedNumericCriteria = [
+      { key: 'readingScore', label: 'Reading', weight: 5.0 },
+      { key: 'mathScore', label: 'Math', weight: 0.5 },
+    ];
+
+    // Second optimization with modified weights
+    const result2 = optimize(
+      students,
+      numClasses,
+      lockedAssignments,
+      modifiedNumericCriteria,
+      baseFlagCriteria,
+      [],
+      [],
+      []
+    );
+
+    // The results should be different because weights changed
+    const assignments1 = Object.entries(result1).sort((a, b) => a[0].localeCompare(b[0]));
+    const assignments2 = Object.entries(result2).sort((a, b) => a[0].localeCompare(b[0]));
+    
+    // At least some assignments should differ
+    let differences = 0;
+    for (let i = 0; i < assignments1.length; i++) {
+      if (assignments1[i][1] !== assignments2[i][1]) {
+        differences++;
+      }
+    }
+    
+    expect(differences).toBeGreaterThan(0);
+  });
+
+  test('changing flag criteria weights produces different optimization results', () => {
+    const numClasses = 3;
+    const lockedAssignments = {};
+
+    // First optimization with base weights
+    const result1 = optimize(
+      students,
+      numClasses,
+      lockedAssignments,
+      baseNumericCriteria,
+      baseFlagCriteria,
+      [],
+      [],
+      []
+    );
+
+    // Change flag weights - emphasize behavior flag more
+    const modifiedFlagCriteria = [
+      { key: 'behavior', label: 'Behavior', weight: 5.0 },
+    ];
+
+    // Second optimization with modified weights
+    const result2 = optimize(
+      students,
+      numClasses,
+      lockedAssignments,
+      baseNumericCriteria,
+      modifiedFlagCriteria,
+      [],
+      [],
+      []
+    );
+
+    // The results should be different because weights changed
+    const assignments1 = Object.entries(result1).sort((a, b) => a[0].localeCompare(b[0]));
+    const assignments2 = Object.entries(result2).sort((a, b) => a[0].localeCompare(b[0]));
+    
+    let differences = 0;
+    for (let i = 0; i < assignments1.length; i++) {
+      if (assignments1[i][1] !== assignments2[i][1]) {
+        differences++;
+      }
+    }
+    
+    expect(differences).toBeGreaterThan(0);
+  });
+
+  test('computeSeed includes weights in hash calculation', () => {
+    const numClasses = 3;
+    const lockedAssignments = {};
+
+    // Compute seed with base weights
+    const seed1 = computeSeed(
+      students,
+      numClasses,
+      lockedAssignments,
+      baseNumericCriteria,
+      baseFlagCriteria,
+      [],
+      [],
+      []
+    );
+
+    // Compute seed with modified weights
+    const modifiedNumericCriteria = [
+      { key: 'readingScore', label: 'Reading', weight: 5.0 },
+      { key: 'mathScore', label: 'Math', weight: 0.5 },
+    ];
+
+    const seed2 = computeSeed(
+      students,
+      numClasses,
+      lockedAssignments,
+      modifiedNumericCriteria,
+      baseFlagCriteria,
+      [],
+      [],
+      []
+    );
+
+    // Seeds should be different when weights change
+    expect(seed1).not.toBe(seed2);
+  });
+
+  test('computeSeed produces same seed for identical criteria', () => {
+    const numClasses = 3;
+    const lockedAssignments = {};
+
+    // Compute seed twice with same criteria
+    const seed1 = computeSeed(
+      students,
+      numClasses,
+      lockedAssignments,
+      baseNumericCriteria,
+      baseFlagCriteria,
+      [],
+      [],
+      []
+    );
+
+    const seed2 = computeSeed(
+      students,
+      numClasses,
+      lockedAssignments,
+      baseNumericCriteria,
+      baseFlagCriteria,
+      [],
+      [],
+      []
+    );
+
+    // Seeds should be identical for identical criteria
+    expect(seed1).toBe(seed2);
+  });
+
+  test('cost calculation reflects weight changes', () => {
+    const numClasses = 3;
+    const lockedAssignments = {};
+
+    // Get initial optimization result
+    const result = optimize(
+      students,
+      numClasses,
+      lockedAssignments,
+      baseNumericCriteria,
+      baseFlagCriteria,
+      [],
+      [],
+      []
+    );
+
+    // Calculate cost with base weights
+    const cost1 = computeCost(
+      students,
+      result,
+      numClasses,
+      baseNumericCriteria,
+      baseFlagCriteria,
+      [],
+      [],
+      []
+    );
+
+    // Calculate cost with modified weights (same assignment)
+    const modifiedNumericCriteria = [
+      { key: 'readingScore', label: 'Reading', weight: 5.0 },
+      { key: 'mathScore', label: 'Math', weight: 0.5 },
+    ];
+
+    const cost2 = computeCost(
+      students,
+      result,
+      numClasses,
+      modifiedNumericCriteria,
+      baseFlagCriteria,
+      [],
+      [],
+      []
+    );
+
+    // Costs should be different with different weights
+    expect(cost1).not.toBe(cost2);
+  });
+
+  test('locked students remain in place when criteria change', () => {
+    const numClasses = 3;
+    
+    // Lock student 1 in class 0
+    const lockedAssignments = { s0: 0 };
+
+    // First optimization
+    const result1 = optimize(
+      students,
+      numClasses,
+      lockedAssignments,
+      baseNumericCriteria,
+      baseFlagCriteria,
+      [],
+      [],
+      []
+    );
+
+    // Verify student 1 is locked
+    expect(result1.s0).toBe(0);
+
+    // Change weights
+    const modifiedNumericCriteria = [
+      { key: 'readingScore', label: 'Reading', weight: 5.0 },
+      { key: 'mathScore', label: 'Math', weight: 0.5 },
+    ];
+
+    // Second optimization with same locked student
+    const result2 = optimize(
+      students,
+      numClasses,
+      lockedAssignments,
+      modifiedNumericCriteria,
+      baseFlagCriteria,
+      [],
+      [],
+      []
+    );
+
+    // Locked student should stay in same class
+    expect(result2.s0).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes a bug where changing configuration settings (flag weights and numeric criteria weights) after optimizing would not trigger re-optimization with the new weights.

## Changes

### Bug Fixes

1. **Include weights in RNG seed** (`src/optimizer.js`)
   - The `computeSeed` function now hashes criterion **weights** along with keys
   - This ensures changing weights produces a different random seed
   - Different seed = different optimization path = results actually change when weights change

2. **Auto-reoptimize when criteria change** (`src/components/OptimizePage.js`)
   - Added useEffect that watches `numericCriteria` and `flagCriteria`
   - Automatically triggers `handleReoptimize()` when criteria change
   - Respects locked students during re-optimization
   - Prevents infinite loops with `optimizing` flag check

### Technical Details

**Root Cause:**
- The RNG seed only hashed criterion **keys**, not **weights**
- When users changed weights, the optimization algorithm started from the exact same random sequence
- Additionally, no auto-reoptimization was triggered when settings changed

**Solution:**
- Modified `computeSeed` to include weights: `hash = fnv(hash, Math.floor((weight || 1) * 1000))`
- Added useEffect to trigger re-optimization: `[numericCriteria, flagCriteria]` dependency array

### Test Coverage

Added comprehensive test suite (`tests/settings-optimization.test.js`) with 6 tests:
- ✅ Changing numeric weights produces different results
- ✅ Changing flag weights produces different results  
- ✅ Seed includes weights in hash calculation
- ✅ Same criteria produce same seed (determinism preserved)
- ✅ Cost calculation reflects weight changes
- ✅ Locked students remain in place when criteria change

**All 170 tests pass** (including 6 new ones)

## Version Bump

- Bumped version from `1.7.2` → `1.7.3` (patch release for bugfix)

## Testing

- [x] All existing tests pass
- [x] New tests verify settings changes affect optimization
- [x] Manual testing: Verified changing weights triggers re-optimization
- [x] Locked students remain in place during auto-reoptimization