### PR TITLE
fix: include keepOutOfClass in project save

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "class-list-builder",
-  "version": "1.7.6",
+  "version": "1.7.7",
   "description": "A tool for optimizing class list distributions",
   "scripts": {
     "build": "node build-standalone.js",

--- a/src/components/ClassColumn.js
+++ b/src/components/ClassColumn.js
@@ -37,14 +37,14 @@ function ClassColumn({ classIdx, name, onNameChange, students, onToggleLock, onD
     const range = mx - mn || 1;
     const classAvg = avg(m.key);
     return {
-      label: m.short,
+      label: m.label,
       val: Math.round(classAvg),
       pct: Math.min(100, Math.max(4, (classAvg - mn) / range * 100)),
     };
   });
 
   const boolCounts = flagCriteria.map(m => ({
-    label: m.short,
+    label: m.label,
     val: students.filter(s => s[m.key]).length,
     colors: generateColor(m.key),
   })).filter(b => b.val > 0);

--- a/src/components/OptimizePage.js
+++ b/src/components/OptimizePage.js
@@ -248,7 +248,7 @@ function OptimizePage({ onBack }) {
             {flagCriteria.map(c => (
               <span key={c.key} style={{ display: 'flex', alignItems: 'center', gap: 3, fontSize: 10.5, color: 'var(--text3)' }} title={c.label}>
                 <span style={{ width: 7, height: 7, borderRadius: '50%', background: generateColor(c.key).dot, flexShrink: 0 }} />
-                {c.short}
+                {c.label}
               </span>
             ))}
           </div>

--- a/src/components/SaveProjectModal.js
+++ b/src/components/SaveProjectModal.js
@@ -15,6 +15,7 @@ function SaveProjectModal({ onClose }) {
     students,
     keepApart,
     keepTogether,
+    keepOutOfClass,
     assignment,
     locked,
     optimizationResults,
@@ -36,6 +37,7 @@ function SaveProjectModal({ onClose }) {
         flagCriteria,
         keepApart,
         keepTogether,
+        keepOutOfClass,
         assignment,
         locked: [...locked], // Convert Set to Array for JSON serialization
         optimizationResults
@@ -121,6 +123,10 @@ function SaveProjectModal({ onClose }) {
           <div className="save-stat-row">
             <span className="save-stat-label">Keep-together groups:</span>
             <span className="save-stat-value">{(keepTogether || []).length}</span>
+          </div>
+          <div className="save-stat-row">
+            <span className="save-stat-label">Keep-out-of-class constraints:</span>
+            <span className="save-stat-value">{(keepOutOfClass || []).length}</span>
           </div>
           {hasAssignment && (
             <div className="save-stat-row">

--- a/src/components/SettingsModal.js
+++ b/src/components/SettingsModal.js
@@ -75,12 +75,6 @@ function SettingsModal({
     return !isNaN(num) && num > 0;
   }
 
-  function validateShort(val) {
-    if (!val || !val.trim()) return false;
-    if (val.includes(',')) return false;
-    return true;
-  }
-
   function updateNumCriteria(index, field, value) {
     setNumCriteria(prev => {
       const next = [...prev];
@@ -101,7 +95,6 @@ function SettingsModal({
     setNumCriteria(prev => [...prev, {
       key: '',
       label: '',
-      short: '',
       weight: 1.0
     }]);
   }
@@ -110,7 +103,6 @@ function SettingsModal({
     setFlagCriteriaState(prev => [...prev, {
       key: '',
       label: '',
-      short: '',
       weight: 1.5
     }]);
   }
@@ -150,10 +142,6 @@ function SettingsModal({
         setError('All criteria must have a label');
         return;
       }
-      if (!validateShort(c.short)) {
-        setError(`Invalid short name for "${c.label}". Short name is required and cannot contain commas.`);
-        return;
-      }
       if (!validateWeight(c.weight)) {
         setError(`Invalid weight for "${c.label}". Weight must be a positive number.`);
         return;
@@ -164,10 +152,6 @@ function SettingsModal({
     for (const c of flagCriteriaState) {
       if (!c.label.trim()) {
         setError('All criteria must have a label');
-        return;
-      }
-      if (!validateShort(c.short)) {
-        setError(`Invalid short name for "${c.label}". Short name is required and cannot contain commas.`);
         return;
       }
       if (!validateWeight(c.weight)) {
@@ -350,7 +334,6 @@ function SettingsModal({
             <div className="settings-section">
               <div className="criteria-header">
                 <div>Display Name</div>
-                <div>Short Name</div>
                 <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
                   Weight
                   <HelpTooltip content={WEIGHTS_HELP_TEXT} />
@@ -365,12 +348,6 @@ function SettingsModal({
                       placeholder="Label (e.g., Reading Score)"
                       value={c.label}
                       onChange={e => updateNumCriteria(i, 'label', e.target.value)}
-                    />
-                    <input
-                      className="form-input"
-                      placeholder="Short (e.g., Read)"
-                      value={c.short}
-                      onChange={e => updateNumCriteria(i, 'short', e.target.value)}
                     />
                     <input
                       className="form-input"
@@ -399,7 +376,6 @@ function SettingsModal({
             <div className="settings-section">
               <div className="criteria-header">
                 <div>Display Name</div>
-                <div>Short Name</div>
                 <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
                   Weight
                   <HelpTooltip content={WEIGHTS_HELP_TEXT} />
@@ -414,12 +390,6 @@ function SettingsModal({
                       placeholder="Label (e.g., Behavior)"
                       value={c.label}
                       onChange={e => updateFlagCriteria(i, 'label', e.target.value)}
-                    />
-                    <input
-                      className="form-input"
-                      placeholder="Short (e.g., BEH)"
-                      value={c.short}
-                      onChange={e => updateFlagCriteria(i, 'short', e.target.value)}
                     />
                     <input
                       className="form-input"

--- a/src/components/SetupPage.js
+++ b/src/components/SetupPage.js
@@ -218,12 +218,12 @@ function SetupPage({ onOptimize }) {
                       <th>G</th>
                       {numericCriteria.map(c => (
                         <th key={c.key} className="col-num" title={c.label}>
-                          {c.short}
+                          {c.label}
                         </th>
                       ))}
                       {flagCriteria.map(c => (
                         <th key={c.key} className="col-check" title={c.label}>
-                          {c.short}
+                          {c.label}
                         </th>
                       ))}
                       <th></th>

--- a/src/contexts/index.js
+++ b/src/contexts/index.js
@@ -385,14 +385,14 @@
     }, []);
 
     const addNumericCriterion = useCallback(
-      (criterion = { key: '', label: '', short: '', weight: 1.0 }) => {
+      (criterion = { key: '', label: '', weight: 1.0 }) => {
         setCriteria(prev => ({ ...prev, numeric: [...prev.numeric, criterion] }));
       },
       []
     );
 
     const addFlagCriterion = useCallback(
-      (criterion = { key: '', label: '', short: '', weight: 1.0 }) => {
+      (criterion = { key: '', label: '', weight: 1.0 }) => {
         setCriteria(prev => ({ ...prev, flag: [...prev.flag, criterion] }));
       },
       []

--- a/src/csv.js
+++ b/src/csv.js
@@ -16,8 +16,8 @@ function escapeCSVValue(value) {
 }
 
 function generateCSVHeaders(numericCriteria, flagCriteria) {
-  const numHeaders = numericCriteria.map(c => c.key);
-  const boolHeaders = flagCriteria.map(c => c.key);
+  const numHeaders = numericCriteria.map(c => c.label);
+  const boolHeaders = flagCriteria.map(c => c.label);
   return ['name', 'gender', ...numHeaders, ...boolHeaders];
 }
 
@@ -61,16 +61,19 @@ function parseCSV(text, numericCriteria, flagCriteria) {
   const keepOutOfClassConstraints = []; // Array<{studentId, classIndex}>
 
   // Build mapping from criteria keys to CSV column indices
+  // Match by normalized label (lowercase, no spaces) since CSV headers use labels
   const numericKeyMap = {};
   const flagKeyMap = {};
 
-  numericCriteria.forEach(({ key }) => {
-    const idx = headers.findIndex(h => h === key.toLowerCase());
+  numericCriteria.forEach(({ key, label }) => {
+    const normalizedLabel = label.toLowerCase().replace(/\s+/g, '');
+    const idx = headers.findIndex(h => h === normalizedLabel);
     if (idx !== -1) numericKeyMap[key] = idx;
   });
 
-  flagCriteria.forEach(({ key }) => {
-    const idx = headers.findIndex(h => h === key.toLowerCase());
+  flagCriteria.forEach(({ key, label }) => {
+    const normalizedLabel = label.toLowerCase().replace(/\s+/g, '');
+    const idx = headers.findIndex(h => h === normalizedLabel);
     if (idx !== -1) flagKeyMap[key] = idx;
   });
 
@@ -193,7 +196,7 @@ function parseCSV(text, numericCriteria, flagCriteria) {
 }
 
 function exportStudentsToCSV(students, numericCriteria, flagCriteria, keepApart = [], keepTogether = [], keepOutOfClass = []) {
-  const headers = ['name', 'gender', ...numericCriteria.map(c => c.key), ...flagCriteria.map(c => c.key), 'keep_apart_group', 'keep_together_group', 'keep_out_of_class'];
+  const headers = ['name', 'gender', ...numericCriteria.map(c => c.label), ...flagCriteria.map(c => c.label), 'keep_apart_group', 'keep_together_group', 'keep_out_of_class'];
   const lines = [headers.join(',')];
 
   // Build a map of student ID to keep-apart group number
@@ -261,7 +264,7 @@ function exportStudentsToCSV(students, numericCriteria, flagCriteria, keepApart 
 }
 
 function exportClassListsToCSV(students, assignment, teachers, numericCriteria, flagCriteria) {
-  const headers = ['class', 'id', 'name', 'gender', ...numericCriteria.map(c => c.key), ...flagCriteria.map(c => c.key)];
+  const headers = ['class', 'id', 'name', 'gender', ...numericCriteria.map(c => c.label), ...flagCriteria.map(c => c.label)];
   const lines = [headers.join(',')];
 
   const sorted = [...students]

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -1,7 +1,7 @@
 const { useState, useEffect, useRef, useCallback, useMemo } = React;
 
 // App version for save/load compatibility checking
-const APP_VERSION = "1.7.6";
+const APP_VERSION = "1.7.7";
 
 const DEFAULT_NUMERIC_CRITERIA = [
   { key: 'englishlanguageartsscore', label: 'English Language Arts Score', short: 'ELA', weight: 1.0 },

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -4,20 +4,20 @@ const { useState, useEffect, useRef, useCallback, useMemo } = React;
 const APP_VERSION = "1.7.7";
 
 const DEFAULT_NUMERIC_CRITERIA = [
-  { key: 'englishlanguageartsscore', label: 'English Language Arts Score', short: 'ELA', weight: 1.0 },
-  { key: 'mathscore', label: 'Math Score', short: 'Math', weight: 1.0 },
-  { key: 'fluency', label: 'Fluency Score', short: 'Fluency', weight: 1.0 },
+  { key: 'englishlanguageartsscore', label: 'English Language Arts Score', weight: 1.0 },
+  { key: 'mathscore', label: 'Math Score', weight: 1.0 },
+  { key: 'fluency', label: 'Fluency Score', weight: 1.0 },
 ];
 
 const DEFAULT_FLAG_CRITERIA = [
-  { key: 'behavior', label: 'Behavior', short: 'BEH', weight: 1.2 },
-  { key: 'extendedlearning', label: 'Extended Learning', short: 'EXL', weight: 1.0 },
-  { key: 'sped', label: 'SPED', short: 'SPED', weight: 1.2 },
-  { key: '_504', label: '504', short: '504', weight: 1.0 },
-  { key: 'readingintervention', label: 'Reading Intervention', short: 'ReadI', weight: 1.0 },
-  { key: 'mathintervention', label: 'Math Intervention', short: 'MathI', weight: 1.0 },
-  { key: 'englishlanguagelearning', label: 'English Language Learning', short: 'ELL', weight: 1.0 },
-  { key: 'medicalplan', label: 'Medical Plan', short: 'Med', weight: 0.8 },
+  { key: 'behavior', label: 'Behavior', weight: 1.2 },
+  { key: 'extendedlearning', label: 'Extended Learning', weight: 1.0 },
+  { key: 'sped', label: 'SPED', weight: 1.2 },
+  { key: '_504', label: '504', weight: 1.0 },
+  { key: 'readingintervention', label: 'Reading Intervention', weight: 1.0 },
+  { key: 'mathintervention', label: 'Math Intervention', weight: 1.0 },
+  { key: 'englishlanguagelearning', label: 'English Language Learning', weight: 1.0 },
+  { key: 'medicalplan', label: 'Medical Plan', weight: 0.8 },
 ];
 
 const STORAGE_KEYS = {

--- a/tests/csv.test.js
+++ b/tests/csv.test.js
@@ -9,13 +9,13 @@ import {
 } from '../src/csv.js';
 
 const numericCriteria = [
-  { key: 'readingScore', label: 'Reading Score', short: 'Read', weight: 1.0 },
-  { key: 'mathScore', label: 'Math Score', short: 'Math', weight: 1.0 },
+  { key: 'readingScore', label: 'Reading Score', weight: 1.0 },
+  { key: 'mathScore', label: 'Math Score', weight: 1.0 },
 ];
 
 const flagCriteria = [
-  { key: 'behavior', label: 'Behavior', short: 'BEH', weight: 2.0 },
-  { key: 'sped', label: 'SPED', short: 'SPED', weight: 2.0 },
+  { key: 'behavior', label: 'Behavior', weight: 2.0 },
+  { key: 'sped', label: 'SPED', weight: 2.0 },
 ];
 
 describe('CSV', () => {
@@ -59,10 +59,10 @@ describe('CSV', () => {
       expect(headers).toEqual([
         'name',
         'gender',
-        'readingScore',
-        'mathScore',
-        'behavior',
-        'sped',
+        'Reading Score',
+        'Math Score',
+        'Behavior',
+        'SPED',
       ]);
     });
 
@@ -77,15 +77,15 @@ describe('CSV', () => {
     test('preserves criteria order', () => {
       // Arrange
       const customNumeric = [
-        { key: 'zScore', label: 'Z Score', short: 'Z', weight: 1.0 },
-        { key: 'aScore', label: 'A Score', short: 'A', weight: 1.0 },
+        { key: 'zScore', label: 'Z Score', weight: 1.0 },
+        { key: 'aScore', label: 'A Score', weight: 1.0 },
       ];
 
       // Act
       const headers = generateCSVHeaders(customNumeric, []);
 
       // Assert
-      expect(headers).toEqual(['name', 'gender', 'zScore', 'aScore']);
+      expect(headers).toEqual(['name', 'gender', 'Z Score', 'A Score']);
     });
   });
 
@@ -142,7 +142,7 @@ describe('CSV', () => {
   describe('parseCSV', () => {
     test('parses valid CSV with headers', () => {
       // Arrange
-      const csv = `name,gender,readingScore,mathScore,behavior,sped
+      const csv = `name,gender,Reading Score,Math Score,Behavior,SPED
 Alice,F,85,90,true,false
 Bob,M,78,82,false,true`;
 
@@ -188,7 +188,7 @@ Bob,M`;
 
     test('returns error for CSV with only header', () => {
       // Arrange
-      const csv = 'name,gender,readingScore';
+      const csv = 'name,gender,Reading Score';
 
       // Act
       const result = parseCSV(csv, numericCriteria, flagCriteria);
@@ -245,7 +245,7 @@ Dave,M,FALSE,no`;
 
     test('generates default names when name column missing', () => {
       // Arrange
-      const csv = `gender,readingScore
+      const csv = `gender,Reading Score
 F,85
 M,78`;
 
@@ -301,7 +301,7 @@ Bob,M`;
 
     test('parses numeric scores with decimals', () => {
       // Arrange
-      const csv = `name,gender,readingScore,mathScore
+      const csv = `name,gender,Reading Score,Math Score
 Alice,F,85.5,90.7`;
 
       // Act
@@ -314,7 +314,7 @@ Alice,F,85.5,90.7`;
 
     test('handles invalid numeric values gracefully', () => {
       // Arrange
-      const csv = `name,gender,readingScore
+      const csv = `name,gender,Reading Score
 Alice,F,invalid
 Bob,F,`;
 
@@ -340,7 +340,7 @@ Bob,F,`;
 
       // Assert
       const lines = csv.split('\n');
-      expect(lines[0]).toBe('name,gender,readingScore,mathScore,behavior,sped,keep_apart_group,keep_together_group,keep_out_of_class');
+      expect(lines[0]).toBe('name,gender,Reading Score,Math Score,Behavior,SPED,keep_apart_group,keep_together_group,keep_out_of_class');
       expect(lines[1]).toBe('Alice,F,85,90,1,0,,,');
       expect(lines[2]).toBe('Bob,M,78,82,0,1,,,');
     });
@@ -369,7 +369,7 @@ Bob,F,`;
       // Assert
       const lines = csv.split('\n');
       expect(lines).toHaveLength(1);
-      expect(lines[0]).toBe('name,gender,readingScore,mathScore,behavior,sped,keep_apart_group,keep_together_group,keep_out_of_class');
+      expect(lines[0]).toBe('name,gender,Reading Score,Math Score,Behavior,SPED,keep_apart_group,keep_together_group,keep_out_of_class');
     });
 
     test('exports keep apart groups to CSV', () => {
@@ -386,7 +386,7 @@ Bob,F,`;
 
       // Assert
       const lines = csv.split('\n');
-      expect(lines[0]).toBe('name,gender,readingScore,mathScore,behavior,sped,keep_apart_group,keep_together_group,keep_out_of_class');
+      expect(lines[0]).toBe('name,gender,Reading Score,Math Score,Behavior,SPED,keep_apart_group,keep_together_group,keep_out_of_class');
       // All three should have group 1
       expect(lines[1]).toBe('Alice,F,85,90,0,0,1,,');
       expect(lines[2]).toBe('Bob,M,78,82,0,0,1,,');
@@ -430,7 +430,7 @@ Bob,F,`;
 
       // Assert
       const lines = csv.split('\n');
-      expect(lines[0]).toBe('class,id,name,gender,readingScore,mathScore,behavior,sped');
+      expect(lines[0]).toBe('class,id,name,gender,Reading Score,Math Score,Behavior,SPED');
       expect(lines[1]).toContain('Mrs. Smith');
       expect(lines[1]).toContain('1'); // ID
       expect(lines[1]).toContain('Alice');
@@ -450,7 +450,7 @@ Bob,F,`;
       const teachers = [{ name: 'Teacher' }];
 
       // Act
-      const csv = exportClassListsToCSV(students, assignment, teachers, [{ key: 'readingScore' }], []);
+      const csv = exportClassListsToCSV(students, assignment, teachers, [{ key: 'readingScore', label: 'Reading Score' }], []);
 
       // Assert
       const lines = csv.split('\n');
@@ -469,7 +469,7 @@ Bob,F,`;
       const teachers = [{ name: 'Class 0' }]; // Only one teacher defined
 
       // Act
-      const csv = exportClassListsToCSV(students, assignment, teachers, [{ key: 'readingScore' }], []);
+      const csv = exportClassListsToCSV(students, assignment, teachers, [{ key: 'readingScore', label: 'Reading Score' }], []);
 
       // Assert
       const lines = csv.split('\n');
@@ -486,7 +486,7 @@ Bob,F,`;
       const teachers = [{ name: 'Teacher' }];
 
       // Act
-      const csv = exportClassListsToCSV(students, assignment, teachers, [{ key: 'readingScore' }], []);
+      const csv = exportClassListsToCSV(students, assignment, teachers, [{ key: 'readingScore', label: 'Reading Score' }], []);
 
       // Assert
       expect(csv).toContain('Alice');
@@ -523,8 +523,8 @@ Bob,F,`;
       ];
 
       // Act
-      const csv = exportStudentsToCSV(students, [{ key: 'readingScore' }], []);
-      const result = parseCSV(csv, [{ key: 'readingScore' }], []);
+      const csv = exportStudentsToCSV(students, [{ key: 'readingScore', label: 'Reading Score' }], []);
+      const result = parseCSV(csv, [{ key: 'readingScore', label: 'Reading Score' }], []);
 
       // Assert - the name is properly escaped and parsed
       expect(result.students[0].name).toBe('Doe, Alice');
@@ -540,8 +540,8 @@ Bob,F,`;
       const keepApart = [['s1', 's2']]; // Alice and Bob should be kept apart
 
       // Act - export then parse
-      const csv = exportStudentsToCSV(students, [{ key: 'readingScore' }], [], keepApart);
-      const result = parseCSV(csv, [{ key: 'readingScore' }], []);
+      const csv = exportStudentsToCSV(students, [{ key: 'readingScore', label: 'Reading Score' }], [], keepApart);
+      const result = parseCSV(csv, [{ key: 'readingScore', label: 'Reading Score' }], []);
 
       // Assert - keepApart pairs are reconstructed from groups
       expect(result.students).toHaveLength(3);
@@ -556,14 +556,14 @@ Bob,F,`;
   describe('keep_apart_group parsing', () => {
     test('parses keep_apart_group column', () => {
       // Arrange
-      const csv = `name,gender,readingScore,keep_apart_group
+      const csv = `name,gender,Reading Score,keep_apart_group
 Alice,F,85,1
 Bob,M,78,1
 Charlie,M,70,2
 Diana,F,92,2`;
 
       // Act
-      const result = parseCSV(csv, [{ key: 'readingScore' }], []);
+      const result = parseCSV(csv, [{ key: 'readingScore', label: 'Reading Score' }], []);
 
       // Assert
       expect(result.students).toHaveLength(4);
@@ -576,12 +576,12 @@ Diana,F,92,2`;
 
     test('parses keepapartgroup (no underscore) column', () => {
       // Arrange
-      const csv = `name,gender,readingScore,keepapartgroup
+      const csv = `name,gender,Reading Score,keepapartgroup
 Alice,F,85,groupA
 Bob,M,78,groupA`;
 
       // Act
-      const result = parseCSV(csv, [{ key: 'readingScore' }], []);
+      const result = parseCSV(csv, [{ key: 'readingScore', label: 'Reading Score' }], []);
 
       // Assert
       expect(result.students).toHaveLength(2);
@@ -590,13 +590,13 @@ Bob,M,78,groupA`;
 
     test('handles empty keep_apart_group values', () => {
       // Arrange
-      const csv = `name,gender,readingScore,keep_apart_group
+      const csv = `name,gender,Reading Score,keep_apart_group
 Alice,F,85,
 Bob,M,78,1
 Charlie,M,70,`;
 
       // Act
-      const result = parseCSV(csv, [{ key: 'readingScore' }], []);
+      const result = parseCSV(csv, [{ key: 'readingScore', label: 'Reading Score' }], []);
 
       // Assert
       expect(result.students).toHaveLength(3);
@@ -605,12 +605,12 @@ Charlie,M,70,`;
 
     test('handles missing keep_apart_group column', () => {
       // Arrange
-      const csv = `name,gender,readingScore
+      const csv = `name,gender,Reading Score
 Alice,F,85
 Bob,M,78`;
 
       // Act
-      const result = parseCSV(csv, [{ key: 'readingScore' }], []);
+      const result = parseCSV(csv, [{ key: 'readingScore', label: 'Reading Score' }], []);
 
       // Assert
       expect(result.students).toHaveLength(2);
@@ -619,13 +619,13 @@ Bob,M,78`;
 
     test('creates all pairs within a group of 3', () => {
       // Arrange - group of 3 should create C(3,2) = 3 pairs
-      const csv = `name,gender,readingScore,keep_apart_group
+      const csv = `name,gender,Reading Score,keep_apart_group
 Alice,F,85,1
 Bob,M,78,1
 Charlie,M,70,1`;
 
       // Act
-      const result = parseCSV(csv, [{ key: 'readingScore' }], []);
+      const result = parseCSV(csv, [{ key: 'readingScore', label: 'Reading Score' }], []);
 
       // Assert
       expect(result.keepApart).toHaveLength(3);
@@ -635,14 +635,14 @@ Charlie,M,70,1`;
   describe('keep_together_group parsing', () => {
     test('parses keep_together_group column', () => {
       // Arrange
-      const csv = `name,gender,readingScore,keep_together_group
+      const csv = `name,gender,Reading Score,keep_together_group
 Alice,F,85,1
 Bob,M,78,1
 Charlie,M,70,2
 Diana,F,92,2`;
 
       // Act
-      const result = parseCSV(csv, [{ key: 'readingScore' }], []);
+      const result = parseCSV(csv, [{ key: 'readingScore', label: 'Reading Score' }], []);
 
       // Assert
       expect(result.students).toHaveLength(4);
@@ -655,12 +655,12 @@ Diana,F,92,2`;
 
     test('parses keeptogethergroup (no underscore) column', () => {
       // Arrange
-      const csv = `name,gender,readingScore,keeptogethergroup
+      const csv = `name,gender,Reading Score,keeptogethergroup
 Alice,F,85,groupA
 Bob,M,78,groupA`;
 
       // Act
-      const result = parseCSV(csv, [{ key: 'readingScore' }], []);
+      const result = parseCSV(csv, [{ key: 'readingScore', label: 'Reading Score' }], []);
 
       // Assert
       expect(result.students).toHaveLength(2);
@@ -669,13 +669,13 @@ Bob,M,78,groupA`;
 
     test('handles empty keep_together_group values', () => {
       // Arrange
-      const csv = `name,gender,readingScore,keep_together_group
+      const csv = `name,gender,Reading Score,keep_together_group
 Alice,F,85,
 Bob,M,78,1
 Charlie,M,70,`;
 
       // Act
-      const result = parseCSV(csv, [{ key: 'readingScore' }], []);
+      const result = parseCSV(csv, [{ key: 'readingScore', label: 'Reading Score' }], []);
 
       // Assert
       expect(result.students).toHaveLength(3);
@@ -684,12 +684,12 @@ Charlie,M,70,`;
 
     test('handles missing keep_together_group column', () => {
       // Arrange
-      const csv = `name,gender,readingScore
+      const csv = `name,gender,Reading Score
 Alice,F,85
 Bob,M,78`;
 
       // Act
-      const result = parseCSV(csv, [{ key: 'readingScore' }], []);
+      const result = parseCSV(csv, [{ key: 'readingScore', label: 'Reading Score' }], []);
 
       // Assert
       expect(result.students).toHaveLength(2);
@@ -698,13 +698,13 @@ Bob,M,78`;
 
     test('creates groups of size 3 correctly', () => {
       // Arrange - group of 3
-      const csv = `name,gender,readingScore,keep_together_group
+      const csv = `name,gender,Reading Score,keep_together_group
 Alice,F,85,1
 Bob,M,78,1
 Charlie,M,70,1`;
 
       // Act
-      const result = parseCSV(csv, [{ key: 'readingScore' }], []);
+      const result = parseCSV(csv, [{ key: 'readingScore', label: 'Reading Score' }], []);
 
       // Assert
       expect(result.keepTogether).toHaveLength(1);
@@ -727,7 +727,7 @@ Charlie,M,70,1`;
 
       // Assert
       const lines = csv.split('\n');
-      expect(lines[0]).toBe('name,gender,readingScore,mathScore,behavior,sped,keep_apart_group,keep_together_group,keep_out_of_class');
+      expect(lines[0]).toBe('name,gender,Reading Score,Math Score,Behavior,SPED,keep_apart_group,keep_together_group,keep_out_of_class');
       // Alice and Bob should have group 1, Charlie should have no group
       expect(lines[1]).toBe('Alice,F,85,90,0,0,,1,');
       expect(lines[2]).toBe('Bob,M,78,82,0,0,,1,');
@@ -769,8 +769,8 @@ Charlie,M,70,1`;
       const keepTogether = [['s1', 's2']]; // Alice and Bob together
 
       // Act - export then parse
-      const csv = exportStudentsToCSV(students, [{ key: 'readingScore' }], [], keepApart, keepTogether);
-      const result = parseCSV(csv, [{ key: 'readingScore' }], []);
+      const csv = exportStudentsToCSV(students, [{ key: 'readingScore', label: 'Reading Score' }], [], keepApart, keepTogether);
+      const result = parseCSV(csv, [{ key: 'readingScore', label: 'Reading Score' }], []);
 
       // Assert - students reconstructed
       expect(result.students).toHaveLength(4);

--- a/tests/custom-criteria.test.js
+++ b/tests/custom-criteria.test.js
@@ -1,0 +1,143 @@
+import { describe, test, expect } from 'vitest';
+import { optimize, computeCost } from '../src/optimizer.js';
+import { serializeProject } from '../src/utils/projectSerializer.js';
+import { deserializeProject } from '../src/utils/projectDeserializer.js';
+import { exportStudentsToCSV, parseCSV } from '../src/csv.js';
+
+// Custom non-default criteria to ensure configuration works end-to-end
+const customNumericCriteria = [
+  { key: 'scienceScore', label: 'Science Score', weight: 1.0 },
+  { key: 'artScore', label: 'Art Score', weight: 1.5 },
+];
+
+const customFlagCriteria = [
+  { key: 'gifted', label: 'Gifted', weight: 2.0 },
+  { key: 'ell', label: 'English Language Learner', weight: 1.0 },
+];
+
+const teachers = [
+  { id: 'T1', name: 'Class A' },
+  { id: 'T2', name: 'Class B' },
+];
+
+const students = [
+  { id: 's1', name: 'Alice', gender: 'F', scienceScore: 85, artScore: 90, gifted: false, ell: false },
+  { id: 's2', name: 'Bob',   gender: 'M', scienceScore: 78, artScore: 82, gifted: true,  ell: false },
+  { id: 's3', name: 'Cara',  gender: 'F', scienceScore: 92, artScore: 88, gifted: false, ell: true },
+  { id: 's4', name: 'Dan',   gender: 'M', scienceScore: 70, artScore: 75, gifted: false, ell: false },
+];
+
+describe('Custom Criteria End-to-End', () => {
+  test('optimizes with custom numeric and flag criteria', () => {
+    const assignment = optimize(
+      students,
+      2, // 2 classes
+      {}, // no locked assignments
+      customNumericCriteria,
+      customFlagCriteria,
+      [], // no keepApart
+      [], // no keepTogether
+      []  // no keepOutOfClass
+    );
+
+    // Should assign all students
+    expect(Object.keys(assignment)).toHaveLength(4);
+    expect(assignment['s1']).toBeDefined();
+    expect(assignment['s2']).toBeDefined();
+    expect(assignment['s3']).toBeDefined();
+    expect(assignment['s4']).toBeDefined();
+
+    // Should use valid class indices
+    expect(assignment['s1']).toBeGreaterThanOrEqual(0);
+    expect(assignment['s1']).toBeLessThan(2);
+  });
+
+  test('computeCost works with custom criteria', () => {
+    const assignment = { s1: 0, s2: 0, s3: 1, s4: 1 };
+    const cost = computeCost(
+      students,
+      assignment,
+      2,
+      customNumericCriteria,
+      customFlagCriteria,
+      [], [], []
+    );
+
+    expect(typeof cost).toBe('number');
+    expect(cost).toBeGreaterThan(0);
+  });
+
+  test('project save/load preserves custom criteria', () => {
+    const state = {
+      students,
+      teachers,
+      numericCriteria: customNumericCriteria,
+      flagCriteria: customFlagCriteria,
+      keepApart: [],
+      keepTogether: [],
+      keepOutOfClass: [],
+      assignment: { s1: 0, s2: 1, s3: 0, s4: 1 },
+      locked: [],
+    };
+
+    const serialized = serializeProject(state);
+    const result = deserializeProject(serialized, {
+      currentVersion: '1.7.7',
+      currentNumCriteria: customNumericCriteria,
+      currentFlagCriteria: customFlagCriteria,
+    });
+
+    expect(result.canLoad).toBe(true);
+    expect(result.errors).toEqual([]);
+    expect(result.data.numericCriteria).toEqual(customNumericCriteria);
+    expect(result.data.flagCriteria).toEqual(customFlagCriteria);
+  });
+
+  test('CSV export uses custom criteria labels as headers', () => {
+    const csv = exportStudentsToCSV(students, customNumericCriteria, customFlagCriteria);
+    const lines = csv.split('\n');
+    const header = lines[0];
+
+    // Headers should use the label, not the key
+    expect(header).toContain('Science Score');
+    expect(header).toContain('Art Score');
+    expect(header).toContain('Gifted');
+    expect(header).toContain('English Language Learner');
+
+    // Should NOT contain the raw keys
+    expect(header).not.toContain('scienceScore');
+    expect(header).not.toContain('artScore');
+    expect(header).not.toContain('gifted');
+    expect(header).not.toContain('ell');
+  });
+
+  test('CSV round-trip preserves custom criteria data', () => {
+    const csv = exportStudentsToCSV(students, customNumericCriteria, customFlagCriteria);
+    const result = parseCSV(csv, customNumericCriteria, customFlagCriteria);
+
+    expect(result.errors).toEqual([]);
+    expect(result.students).toHaveLength(4);
+
+    // Verify data preserved
+    const alice = result.students.find(s => s.name === 'Alice');
+    expect(alice.scienceScore).toBe(85);
+    expect(alice.artScore).toBe(90);
+    expect(alice.gifted).toBe(false);
+    expect(alice.ell).toBe(false);
+
+    const bob = result.students.find(s => s.name === 'Bob');
+    expect(bob.scienceScore).toBe(78);
+    expect(bob.gifted).toBe(true);
+  });
+
+  test('optimization with custom criteria produces deterministic results', () => {
+    const assignment1 = optimize(
+      students, 2, {}, customNumericCriteria, customFlagCriteria, [], [], []
+    );
+    const assignment2 = optimize(
+      students, 2, {}, customNumericCriteria, customFlagCriteria, [], [], []
+    );
+
+    expect(assignment1).toEqual(assignment2);
+  });
+});

--- a/tests/display-normalization.test.js
+++ b/tests/display-normalization.test.js
@@ -30,7 +30,7 @@ function calculateClassColumnStats(students, allStudents, numericCriteria) {
     const range = mx - mn || 1;
     const classAvg = avg(m.key);
     return {
-      label: m.short,
+      label: m.label,
       val: Math.round(classAvg),
       pct: Math.min(100, Math.max(4, (classAvg - mn) / range * 100)),
       raw: classAvg,
@@ -69,9 +69,9 @@ function calculateStatsStripNormalization(students, assignment, numClasses, nume
 
 // Mixed range criteria matching the application defaults
 const mixedRangeCriteria = [
-  { key: 'readingScore', label: 'Reading Score', short: 'Read', weight: 1.0 },
-  { key: 'mathScore', label: 'Math Score', short: 'Math', weight: 1.0 },
-  { key: 'languageScore', label: 'Language Score', short: 'Lang', weight: 1.0 },
+  { key: 'readingScore', label: 'Reading Score', weight: 1.0 },
+  { key: 'mathScore', label: 'Math Score', weight: 1.0 },
+  { key: 'languageScore', label: 'Language Score', weight: 1.0 },
 ];
 
 describe('Display Normalization with Mixed Score Ranges', () => {
@@ -90,7 +90,7 @@ describe('Display Normalization with Mixed Score Ranges', () => {
 
       // Act - simulate ClassColumn stats calculation
       const stats = calculateClassColumnStats(students, students, mixedRangeCriteria);
-      const readingStat = stats.find(s => s.label === 'Read');
+      const readingStat = stats.find(s => s.label === 'Reading Score');
 
       // Assert
       expect(readingStat.min).toBe(0);
@@ -110,7 +110,7 @@ describe('Display Normalization with Mixed Score Ranges', () => {
 
       // Act
       const stats = calculateClassColumnStats(students, students, mixedRangeCriteria);
-      const mathStat = stats.find(s => s.label === 'Math');
+      const mathStat = stats.find(s => s.label === 'Math Score');
 
       // Assert
       expect(mathStat.min).toBe(2000);
@@ -130,7 +130,7 @@ describe('Display Normalization with Mixed Score Ranges', () => {
 
       // Act
       const stats = calculateClassColumnStats(students, students, mixedRangeCriteria);
-      const readingStat = stats.find(s => s.label === 'Read');
+      const readingStat = stats.find(s => s.label === 'Reading Score');
 
       // Assert - when min = max, range is set to 1 to avoid division by zero
       expect(readingStat.min).toBe(100);
@@ -151,7 +151,7 @@ describe('Display Normalization with Mixed Score Ranges', () => {
 
       // Act
       const stats = calculateClassColumnStats(classStudents, allStudents, mixedRangeCriteria);
-      const readingStat = stats.find(s => s.label === 'Read');
+      const readingStat = stats.find(s => s.label === 'Reading Score');
 
       // Assert - minimum percentage should be 4%
       expect(readingStat.pct).toBeGreaterThanOrEqual(4);
@@ -169,7 +169,7 @@ describe('Display Normalization with Mixed Score Ranges', () => {
 
       // Act
       const stats = calculateClassColumnStats(classStudents, allStudents, mixedRangeCriteria);
-      const readingStat = stats.find(s => s.label === 'Read');
+      const readingStat = stats.find(s => s.label === 'Reading Score');
 
       // Assert - percentage should not exceed 100%
       expect(readingStat.pct).toBeLessThanOrEqual(100);
@@ -205,8 +205,8 @@ describe('Display Normalization with Mixed Score Ranges', () => {
       });
 
       // Class 1 should have lower average reading scores
-      expect(stats1.find(s => s.label === 'Read').raw).toBeLessThan(
-        stats2.find(s => s.label === 'Read').raw
+      expect(stats1.find(s => s.label === 'Reading Score').raw).toBeLessThan(
+        stats2.find(s => s.label === 'Reading Score').raw
       );
     });
   });
@@ -403,7 +403,7 @@ describe('Display Normalization with Mixed Score Ranges', () => {
       ];
 
       const stats = calculateClassColumnStats(students, students, mixedRangeCriteria);
-      const readingStat = stats.find(s => s.label === 'Read');
+      const readingStat = stats.find(s => s.label === 'Reading Score');
 
       expect(readingStat.range).toBe(1);
       expect(readingStat.pct).toBeGreaterThanOrEqual(4);
@@ -417,13 +417,13 @@ describe('Display Normalization with Mixed Score Ranges', () => {
       ];
 
       const stats = calculateClassColumnStats(students, students, mixedRangeCriteria);
-      const readingStat = stats.find(s => s.label === 'Read');
+      const readingStat = stats.find(s => s.label === 'Reading Score');
 
       expect(readingStat.min).toBe(0);
       expect(readingStat.max).toBe(100);
       // Class with 0 reading score should have 4% (minimum) percentage
       const zeroScoreStats = calculateClassColumnStats([students[0]], students, mixedRangeCriteria);
-      const zeroReadingStat = zeroScoreStats.find(s => s.label === 'Read');
+      const zeroReadingStat = zeroScoreStats.find(s => s.label === 'Reading Score');
       expect(zeroReadingStat.pct).toBe(4);
     });
 
@@ -434,7 +434,7 @@ describe('Display Normalization with Mixed Score Ranges', () => {
       ];
 
       const stats = calculateClassColumnStats(students, students, mixedRangeCriteria);
-      const readingStat = stats.find(s => s.label === 'Read');
+      const readingStat = stats.find(s => s.label === 'Reading Score');
 
       expect(readingStat.min).toBe(-100);
       expect(readingStat.max).toBe(100);

--- a/tests/optimizer.test.js
+++ b/tests/optimizer.test.js
@@ -39,15 +39,15 @@ function createMockStudents(count, options = {}) {
 }
 
 const numericCriteria = [
-  { key: 'readingScore', label: 'Reading Score', short: 'Read', weight: 1.0 },
-  { key: 'mathScore', label: 'Math Score', short: 'Math', weight: 1.0 },
-  { key: 'languageScore', label: 'Language Score', short: 'Lang', weight: 1.0 },
+  { key: 'readingScore', label: 'Reading Score', weight: 1.0 },
+  { key: 'mathScore', label: 'Math Score', weight: 1.0 },
+  { key: 'languageScore', label: 'Language Score', weight: 1.0 },
 ];
 
 const flagCriteria = [
-  { key: 'behavior', label: 'Behavior', short: 'BEH', weight: 2.0 },
-  { key: 'extendedLearning', label: 'Extended Learning', short: 'ExtL', weight: 1.5 },
-  { key: 'sped', label: 'SPED', short: 'SPED', weight: 2.0 },
+  { key: 'behavior', label: 'Behavior', weight: 2.0 },
+  { key: 'extendedLearning', label: 'Extended Learning', weight: 1.5 },
+  { key: 'sped', label: 'SPED', weight: 2.0 },
 ];
 
 describe('Optimizer', () => {
@@ -1084,16 +1084,16 @@ describe('Optimizer', () => {
       
       // High-weighted flag criteria (behavior=3.0, extendedLearning=0.5)
       const weightedFlagCriteria = [
-        { key: 'behavior', label: 'Behavior', short: 'BEH', weight: 3.0 },
-        { key: 'extendedLearning', label: 'Extended Learning', short: 'ExtL', weight: 0.5 },
-        { key: 'sped', label: 'SPED', short: 'SPED', weight: 1.0 },
+        { key: 'behavior', label: 'Behavior', weight: 3.0 },
+        { key: 'extendedLearning', label: 'Extended Learning', weight: 0.5 },
+        { key: 'sped', label: 'SPED', weight: 1.0 },
       ];
       
       // Equal-weighted flag criteria (all 1.0)
       const equalFlagCriteria = [
-        { key: 'behavior', label: 'Behavior', short: 'BEH', weight: 1.0 },
-        { key: 'extendedLearning', label: 'Extended Learning', short: 'ExtL', weight: 1.0 },
-        { key: 'sped', label: 'SPED', short: 'SPED', weight: 1.0 },
+        { key: 'behavior', label: 'Behavior', weight: 1.0 },
+        { key: 'extendedLearning', label: 'Extended Learning', weight: 1.0 },
+        { key: 'sped', label: 'SPED', weight: 1.0 },
       ];
       
       const numClasses = 2;
@@ -1118,12 +1118,12 @@ describe('Optimizer', () => {
       
       // High weight for behavior
       const highWeightCriteria = [
-        { key: 'behavior', label: 'Behavior', short: 'BEH', weight: 2.0 },
+        { key: 'behavior', label: 'Behavior', weight: 2.0 },
       ];
       
       // Low weight for behavior
       const lowWeightCriteria = [
-        { key: 'behavior', label: 'Behavior', short: 'BEH', weight: 0.1 },
+        { key: 'behavior', label: 'Behavior', weight: 0.1 },
       ];
       
       const numClasses = 2;
@@ -1149,14 +1149,14 @@ describe('Optimizer', () => {
       
       // High weight on reading
       const readingWeightedCriteria = [
-        { key: 'readingScore', label: 'Reading Score', short: 'Read', weight: 3.0 },
-        { key: 'mathScore', label: 'Math Score', short: 'Math', weight: 1.0 },
+        { key: 'readingScore', label: 'Reading Score', weight: 3.0 },
+        { key: 'mathScore', label: 'Math Score', weight: 1.0 },
       ];
       
       // Equal weights
       const equalCriteria = [
-        { key: 'readingScore', label: 'Reading Score', short: 'Read', weight: 1.0 },
-        { key: 'mathScore', label: 'Math Score', short: 'Math', weight: 1.0 },
+        { key: 'readingScore', label: 'Reading Score', weight: 1.0 },
+        { key: 'mathScore', label: 'Math Score', weight: 1.0 },
       ];
       
       const numClasses = 2;
@@ -1190,9 +1190,9 @@ describe('Optimizer', () => {
       
       // Behavior weighted higher than extended learning
       const weightedCriteria = [
-        { key: 'behavior', label: 'Behavior', short: 'BEH', weight: 3.0 },
-        { key: 'extendedLearning', label: 'Extended Learning', short: 'ExtL', weight: 1.0 },
-        { key: 'sped', label: 'SPED', short: 'SPED', weight: 1.0 },
+        { key: 'behavior', label: 'Behavior', weight: 3.0 },
+        { key: 'extendedLearning', label: 'Extended Learning', weight: 1.0 },
+        { key: 'sped', label: 'SPED', weight: 1.0 },
       ];
       
       const numClasses = 2;
@@ -1220,7 +1220,7 @@ describe('Optimizer', () => {
       
       // Behavior has zero weight
       const zeroWeightCriteria = [
-        { key: 'behavior', label: 'Behavior', short: 'BEH', weight: 0 },
+        { key: 'behavior', label: 'Behavior', weight: 0 },
       ];
       
       const numClasses = 2;

--- a/tests/project-serialize.test.js
+++ b/tests/project-serialize.test.js
@@ -3,13 +3,13 @@ import { serializeProject } from '../src/utils/projectSerializer.js';
 import { deserializeProject } from '../src/utils/projectDeserializer.js';
 
 const numericCriteria = [
-  { key: 'readingScore', label: 'Reading Score', short: 'Read', weight: 1.0 },
-  { key: 'mathScore', label: 'Math Score', short: 'Math', weight: 1.0 },
+  { key: 'readingScore', label: 'Reading Score', weight: 1.0 },
+  { key: 'mathScore', label: 'Math Score', weight: 1.0 },
 ];
 
 const flagCriteria = [
-  { key: 'behavior', label: 'Behavior', short: 'BEH', weight: 2.0 },
-  { key: 'sped', label: 'SPED', short: 'SPED', weight: 2.0 },
+  { key: 'behavior', label: 'Behavior', weight: 2.0 },
+  { key: 'sped', label: 'SPED', weight: 2.0 },
 ];
 
 const teachers = [

--- a/tests/score-ranges.test.js
+++ b/tests/score-ranges.test.js
@@ -85,15 +85,15 @@ function createDecimalScoreStudents(count) {
 
 // Criteria definitions
 const mixedRangeCriteria = [
-  { key: 'readingScore', label: 'Reading Score', short: 'Read', weight: 1.0 },
-  { key: 'mathScore', label: 'Math Score', short: 'Math', weight: 1.0 },
-  { key: 'languageScore', label: 'Language Score', short: 'Lang', weight: 1.0 },
+  { key: 'readingScore', label: 'Reading Score', weight: 1.0 },
+  { key: 'mathScore', label: 'Math Score', weight: 1.0 },
+  { key: 'languageScore', label: 'Language Score', weight: 1.0 },
 ];
 
 const flagCriteria = [
-  { key: 'behavior', label: 'Behavior', short: 'BEH', weight: 2.0 },
-  { key: 'extendedLearning', label: 'Extended Learning', short: 'ExtL', weight: 1.5 },
-  { key: 'sped', label: 'SPED', short: 'SPED', weight: 2.0 },
+  { key: 'behavior', label: 'Behavior', weight: 2.0 },
+  { key: 'extendedLearning', label: 'Extended Learning', weight: 1.5 },
+  { key: 'sped', label: 'SPED', weight: 2.0 },
 ];
 
 describe('Numeric Score Range Handling', () => {
@@ -440,9 +440,9 @@ describe('Numeric Score Range Handling', () => {
 
       // Assert
       const lines = csv.split('\n');
-      expect(lines[0]).toContain('readingScore');
-      expect(lines[0]).toContain('mathScore');
-      expect(lines[0]).toContain('languageScore');
+      expect(lines[0]).toContain('Reading Score');
+      expect(lines[0]).toContain('Math Score');
+      expect(lines[0]).toContain('Language Score');
       expect(lines[1]).toContain('150');
       expect(lines[1]).toContain('2500');
       expect(lines[1]).toContain('2200');
@@ -450,7 +450,7 @@ describe('Numeric Score Range Handling', () => {
 
     test('imports students with mixed score ranges', () => {
       // Arrange
-      const csv = `name,gender,readingScore,mathScore,languageScore,behavior,sped
+      const csv = `name,gender,Reading Score,Math Score,Language Score,Behavior,SPED
 Alice,F,150,2500,2200,false,false
 Bob,M,200,2800,2750,true,false`;
 
@@ -568,7 +568,7 @@ Bob,M,200,2800,2750,true,false`;
 
   describe('Numeric Criteria Edge Cases', () => {
     test('handles single numeric criterion', () => {
-      const singleCriterion = [{ key: 'readingScore', label: 'Reading', short: 'Read', weight: 1.0 }];
+      const singleCriterion = [{ key: 'readingScore', label: 'Reading', weight: 1.0 }];
       const students = [];
       for (let i = 0; i < 10; i++) {
         students.push({
@@ -590,11 +590,11 @@ Bob,M,200,2800,2750,true,false`;
 
     test('handles many numeric criteria', () => {
       const manyCriteria = [
-        { key: 'score1', label: 'Score 1', short: 'S1', weight: 1.0 },
-        { key: 'score2', label: 'Score 2', short: 'S2', weight: 1.0 },
-        { key: 'score3', label: 'Score 3', short: 'S3', weight: 1.0 },
-        { key: 'score4', label: 'Score 4', short: 'S4', weight: 1.0 },
-        { key: 'score5', label: 'Score 5', short: 'S5', weight: 1.0 },
+        { key: 'score1', label: 'Score 1', weight: 1.0 },
+        { key: 'score2', label: 'Score 2', weight: 1.0 },
+        { key: 'score3', label: 'Score 3', weight: 1.0 },
+        { key: 'score4', label: 'Score 4', weight: 1.0 },
+        { key: 'score5', label: 'Score 5', weight: 1.0 },
       ];
 
       const students = [];


### PR DESCRIPTION
## Summary
This PR fixes two issues:

### 1. Fix: Keep-out-of-class constraints lost on save
SaveProjectModal was not reading `keepOutOfClass` from StudentsContext and not passing it to `serializeProject()`, causing keep-out-of-class constraints to be silently dropped when saving projects.

### 2. Refactor: Remove confusing 3-name criteria system
Previously criteria had 3 names (key, label, short) causing confusion — the CSV header used `key` (e.g., `fluency`) which appeared nowhere in the UI where user configured `label` ("Fluency Score") and `short` ("Fluency").

**Now criteria have only 2 names:**
- `key`: Machine identifier (auto-generated from label, used internally)
- `label`: Display name shown everywhere in UI and CSV headers

**Changes:**
- Remove `short` field from all criteria objects and Settings modal
- Use `label` for table headers, stats bars, and legend (was `short`)
- CSV export/import now uses `label` for column headers
- User sees consistent names: configure "Fluency Score", see "Fluency Score" in tables, download CSV with "Fluency Score" header

### Testing
- All 176 tests pass (170 existing + 6 new custom-criteria end-to-end tests)
- Lint passes (126 warnings, 0 errors — same as baseline)
- New `custom-criteria.test.js` verifies non-default criteria work for: configuration, optimization, save/load round-trip, CSV export/import round-trip

### Version
Bumped to 1.7.7