### PR TITLE
chore: maintenance cleanup and bug fixes (v1.7.10)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 Create balanced class lists in minutes.
 
+> ### ▶ [**Open Class List Builder in your browser →**](https://armstrys.github.io/class-list-builder/)
+>
+> No download. No accounts. Your data stays on your computer.
+
 ![App Screenshot](docs/images/app-screenshot.png)
 
 This tool distributes students across classrooms while balancing academic scores, intervention needs, gender, and class size. It runs entirely in your browser. **Student data never leaves your computer.**
@@ -20,10 +24,6 @@ Building fair class lists by hand takes too long. You're juggling a dozen factor
 - **Handles any size.** Small schools or large districts. The optimization runs in seconds even with thousands of students.
 
 ---
-
-## Try It Now
-
-**[Use it in your browser](https://armstrys.github.io/class-list-builder/)** — No download needed. Your data stays local.
 
 ## Download & Open
 

--- a/build-standalone.js
+++ b/build-standalone.js
@@ -354,7 +354,7 @@ async function build() {
 
     console.log('\n💡 Next steps:');
     console.log('   • Run tests: npm test');
-    console.log('   • Run lint: npm run lint (after: npm install eslint)');
+    console.log('   • Run lint:  npm run lint');
 
   } catch (err) {
     console.error('\n❌ Build failed:', err.message);

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -1,6 +1,6 @@
 # Security & Privacy
 
-**Version:** 1.6.0 | **Last Updated:** April 30, 2026
+**Version:** 1.7.10 | **Last Updated:** May 16, 2026
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "class-list-builder",
-  "version": "1.7.9",
+  "version": "1.7.10",
   "description": "A tool for optimizing class list distributions",
   "scripts": {
     "build": "node build-standalone.js",

--- a/scripts/setup-hooks.sh
+++ b/scripts/setup-hooks.sh
@@ -28,8 +28,9 @@ if [ -n "$STAGED_JS" ]; then
 fi
 
 # Check bundle size threshold
-if [ -f "dist/class-list-builder-v*.html" ]; then
-    BUNDLE_SIZE=$(stat -f%z dist/class-list-builder-v*.html 2>/dev/null || stat -c%s dist/class-list-builder-v*.html 2>/dev/null)
+BUNDLE_FILE=$(ls dist/class-list-builder-v*.html 2>/dev/null | head -1)
+if [ -n "$BUNDLE_FILE" ] && [ -f "$BUNDLE_FILE" ]; then
+    BUNDLE_SIZE=$(stat -f%z "$BUNDLE_FILE" 2>/dev/null || stat -c%s "$BUNDLE_FILE" 2>/dev/null)
     SIZE_MB=$(echo "scale=2; $BUNDLE_SIZE / 1024 / 1024" | bc)
     if (( $(echo "$SIZE_MB > 5.0" | bc -l) )); then
         echo "❌ Error: Bundle size (${SIZE_MB}MB) exceeds 5MB threshold"

--- a/scripts/validate-build.js
+++ b/scripts/validate-build.js
@@ -8,12 +8,18 @@
  */
 
 const fs = require('fs');
+const path = require('path');
 const acorn = require('acorn');
 const acornJsx = require('acorn-jsx');
 
 const Parser = acorn.Parser.extend(acornJsx());
 
-const file = process.argv[2] || 'dist/class-list-builder-v1.5.0.html';
+function defaultBuildPath() {
+  const pkg = JSON.parse(fs.readFileSync(path.resolve(__dirname, '..', 'package.json'), 'utf8'));
+  return `dist/class-list-builder-v${pkg.version}.html`;
+}
+
+const file = process.argv[2] || defaultBuildPath();
 
 if (!fs.existsSync(file)) {
   console.error(`File not found: ${file}`);

--- a/src/app.js
+++ b/src/app.js
@@ -35,9 +35,6 @@ function AppContent() {
     setTeachers,
   } = useAppStateExport();
 
-  // Welcome modal state
-  const [, setShowWelcome] = React.useState(true);
-
   const {
     students,
     setStudents,
@@ -79,8 +76,8 @@ function AppContent() {
       if (data.teachers) setTeachers(data.teachers);
       if (data.numericCriteria) setNumericCriteria(data.numericCriteria);
       if (data.flagCriteria) setFlagCriteria(data.flagCriteria);
-      // Assignment, locked, constraints, and optimizationResults are already
-      // set by replaceAllStudents. Restore them from project if present.
+      // replaceAllStudents reset constraints/assignment/locked to empty;
+      // restore them from the project payload if present.
       if (data.keepApart?.length > 0) setKeepApart(data.keepApart);
       if (data.keepTogether?.length > 0) setKeepTogether(data.keepTogether);
       if (data.keepOutOfClass?.length > 0) setKeepOutOfClass(data.keepOutOfClass);
@@ -195,12 +192,9 @@ function AppContent() {
       )}
 
       <WelcomeModal
-        onClose={() => setShowWelcome(false)}
         onLoadDemo={() => {
-          // Load demo data with default sample students
           const demoStudents = generateSampleStudents(100, numericCriteria, flagCriteria);
           replaceAllStudents(demoStudents);
-          setShowWelcome(false);
         }}
       />
     </div>

--- a/src/components/Modal.js
+++ b/src/components/Modal.js
@@ -33,7 +33,7 @@ function Modal({
   const overlayRef = useRef(null);
   const modalRef = useRef(null);
   const previouslyFocusedRef = useRef(null);
-  const titleId = useMemo(() => `modal-title-${Math.random().toString(36).substr(2, 9)}`, []);
+  const titleId = useMemo(() => `modal-title-${Math.random().toString(36).slice(2, 11)}`, []);
 
   // Size-based max widths
   const sizeStyles = {

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -1,7 +1,7 @@
 const { useState, useEffect, useRef, useCallback, useMemo } = React;
 
 // App version for save/load compatibility checking
-const APP_VERSION = "1.7.9";
+const APP_VERSION = "1.7.10";
 
 const DEFAULT_NUMERIC_CRITERIA = [
   { key: 'englishlanguageartsscore', label: 'English Language Arts Score', weight: 1.0 },
@@ -21,8 +21,8 @@ const DEFAULT_FLAG_CRITERIA = [
 ];
 
 const STORAGE_KEYS = {
-  NUMERIC_CRITERIA: 'class-optimizer-numeric-criteria',
-  FLAG_CRITERIA: 'class-optimizer-flag-criteria',
+  NUMERIC_CRITERIA: 'classOptimizer_numericCriteria_v2',
+  FLAG_CRITERIA: 'classOptimizer_flagCriteria_v2',
 };
 
 // Optimization penalty weights

--- a/src/sample-data.js
+++ b/src/sample-data.js
@@ -39,14 +39,14 @@ function generateSampleStudents(count = 27, numericCriteria, flagCriteria) {
     const mathIntervention = p(0.16) && !gt;
 
     flagCriteria.forEach(({ key }) => {
-      if (key === 'extendedLearning') student[key] = gt;
+      if (key === 'extendedlearning') student[key] = gt;
       else if (key === 'sped') student[key] = sped;
       else if (key === 'behavior') student[key] = behavior;
-      else if (key === '504') student[key] = flag504;
-      else if (key === 'readingIntervention') student[key] = readingIntervention;
-      else if (key === 'mathIntervention') student[key] = mathIntervention;
-      else if (key === 'englishLanguageLearning') student[key] = ell;
-      else if (key === 'medicalPlan') student[key] = p(0.06);
+      else if (key === '_504') student[key] = flag504;
+      else if (key === 'readingintervention') student[key] = readingIntervention;
+      else if (key === 'mathintervention') student[key] = mathIntervention;
+      else if (key === 'englishlanguagelearning') student[key] = ell;
+      else if (key === 'medicalplan') student[key] = p(0.06);
       else student[key] = p(0.15);
     });
 

--- a/tests/state-management.test.js
+++ b/tests/state-management.test.js
@@ -9,10 +9,6 @@ describe('State Management - replaceAllStudents', () => {
   /**
    * Simulates the replaceAllStudents function from StudentsContext
    */
-
-  /**
-   * Simulates the replaceAllStudents function from StudentsContext
-   */
   function replaceAllStudents(newStudents) {
     return {
       students: newStudents,


### PR DESCRIPTION
## Summary

General maintenance pass — no structural refactor, just bug fixes and minor cleanup. Bumps to **v1.7.10**.

### Bugs fixed
- **`src/sample-data.js`**: flag keys were camelCase (`extendedLearning`, `readingIntervention`, `'504'`) but `defaults.js` uses lowercase (`extendedlearning`, `readingintervention`, `_504`). Every targeted distribution was silently falling through to the generic `p(0.15)` fallback, making sample data less realistic than intended.
- **`SettingsModal` "Clear Cache"**: `STORAGE_KEYS` in `defaults.js` didn't match the v2 keys actually written by `CriteriaContext` (`classOptimizer_*_v2`), so the button was a no-op against real saved settings. Updated `STORAGE_KEYS` values to match.
- **`scripts/validate-build.js`**: hardcoded default `dist/class-list-builder-v1.5.0.html` no longer exists. Now derives the default path from `package.json` version.
- **`scripts/setup-hooks.sh`**: `[ -f "dist/class-list-builder-v*.html" ]` glob doesn't expand inside `-f`; bundle-size check never ran. Fixed with `ls` + `-n` check.

### Cleanups
- `src/app.js`: removed dead `useState` whose value was discarded (`WelcomeModal` manages its own visibility); fixed misleading `handleLoadProject` comment.
- `src/components/Modal.js`: deprecated `String.substr` → `slice`.
- `build-standalone.js`: dropped stale "after: npm install eslint" hint.
- `tests/state-management.test.js`: removed duplicate JSDoc block.
- `docs/SECURITY.md`: refreshed version (1.6.0 → 1.7.10) and date.
- **`README.md`**: hoisted the website link into a prominent quote-block call-to-action right under the title.

### Version
- `package.json`: 1.7.9 → 1.7.10
- `src/defaults.js` `APP_VERSION`: 1.7.9 → 1.7.10
- `docs/SECURITY.md` version header: 1.6.0 → 1.7.10

## Test plan

- [x] `npm run lint` — 0 errors (122 pre-existing warnings unchanged)
- [x] `npm test` — 162/162 passing
- [x] `npm run build` — succeeds, output `dist/class-list-builder-v1.7.10.html`
- [x] `node scripts/validate-build.js` — picks up new default path, parses OK
- [x] Visual check of README on GitHub (prominent CTA renders as expected)
- [ ] Spot-check Settings → Clear Cache actually clears localStorage now
- [ ] Spot-check sample data generation produces realistic distributions

🤖 Generated with [Claude Code](https://claude.com/claude-code)