### PR TITLE
fix: data integrity, dead-code cleanup, and effect hygiene (v1.7.11)

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,18 +72,16 @@ Your CSV needs at minimum a `name` column and a `gender` column (`M` or `F`). Al
 
 **Import appends** to your current student list. Click **Clear All** first if you want to replace your entire list.
 
-**Constraint Columns (optional):**
-- `keep_apart_group` — students with the same value stay in different classes
-- `keep_together_group` — students with the same value stay in the same class
-
 Example CSV:
 ```
-name,gender,readingScore,keep_apart_group,keep_together_group
-Alice,F,85,1,
-Bob,M,78,1,
-Charlie,M,70,,1
-Diana,F,92,,1
+name,gender,readingScore,sped,behavior
+Alice,F,85,0,0
+Bob,M,78,1,0
+Charlie,M,70,0,1
+Diana,F,92,0,0
 ```
+
+Constraints (keep apart / keep together) aren't stored in CSV — set them up in the **Constraints** dialog and persist them by saving the project as JSON (**Save Project**).
 
 **Option B: Add students manually**
 
@@ -161,7 +159,7 @@ Constraints are treated as high-priority requests, not absolute rules. If the op
 - Class size limits (asking 15 students to stay together when classes max at 12)
 - Balance trade-offs where satisfying constraints would make classes extremely unbalanced
 
-Constraints are cleared when you import new students. Use the `keep_apart_group` and `keep_together_group` CSV columns to persist them.
+Importing a CSV appends students but doesn't clear existing constraints. To persist constraints across sessions, use **Save Project** (JSON) — CSV doesn't carry constraints.
 
 ### Export
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "class-list-builder",
-  "version": "1.7.10",
+  "version": "1.7.11",
   "description": "A tool for optimizing class list distributions",
   "scripts": {
     "build": "node build-standalone.js",

--- a/src/components/ImportModal.js
+++ b/src/components/ImportModal.js
@@ -120,12 +120,12 @@ function ImportModal({ onImport, onClose, numericCriteria, flagCriteria, student
       return;
     }
     
-    const { students: importedStudents, errors, keepApart, keepTogether } = parseCSV(text, numericCriteria, flagCriteria);
+    const { students: importedStudents, errors } = parseCSV(text, numericCriteria, flagCriteria);
     if (!importedStudents.length) {
       setError(errors.length ? errors.join('; ') : 'No valid students found. Check your CSV format.');
       return;
     }
-    onImport(importedStudents, keepApart, keepTogether);
+    onImport(importedStudents);
     if (errors.length) {
       window.alert(`⚠️ Imported ${importedStudents.length} students with warnings:\n\n${errors.join('\n')}`);
     }

--- a/src/components/LoadProjectModal.js
+++ b/src/components/LoadProjectModal.js
@@ -126,8 +126,8 @@ function LoadProjectModal({
 
   function renderVersionInfo() {
     if (!validationResult) return null;
-    
-    const { metadata } = validationResult.data?._raw || {};
+
+    const metadata = validationResult.data?.metadata;
     if (!metadata) return null;
 
     return (

--- a/src/components/OptimizePage.js
+++ b/src/components/OptimizePage.js
@@ -83,19 +83,23 @@ function OptimizePage({ onBack }) {
     }
   }, [numericCriteria, flagCriteria, students, assignment, numClasses, keepApart, keepTogether, keepOutOfClass]);
 
-  function handleReoptimize() {
+  const handleReoptimize = useCallback(() => {
     const lockedObj = new Map();
     locked.forEach(sid => {
       if (assignment[sid] !== undefined) lockedObj.set(sid, assignment[sid]);
     });
     runOptimize(lockedObj);
-  }
+  }, [locked, assignment, runOptimize]);
 
-  // Auto-reoptimize when criteria change (respecting locked students)
+  // Auto-reoptimize when criteria change (respecting locked students).
+  // Deps are intentionally limited to criteria — adding assignment/optimizing/
+  // handleReoptimize would re-trigger this on every reoptimize result and
+  // cause a runaway loop.
   useEffect(() => {
     if (assignment && Object.keys(assignment).length > 0 && !optimizing) {
       handleReoptimize();
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [numericCriteria, flagCriteria]);
 
   function handleToggleLock(sid) {

--- a/src/components/SettingsModal.js
+++ b/src/components/SettingsModal.js
@@ -160,24 +160,27 @@ function SettingsModal({
       }
     }
 
-    // Check for duplicate keys
-    const allKeys = [...numCriteria.map(c => generateKeyFromLabel(c.label)), ...flagCriteriaState.map(c => generateKeyFromLabel(c.label))];
-    const uniqueKeys = new Set(allKeys);
-    if (uniqueKeys.size !== allKeys.length) {
+    // Check for duplicate labels (label is the user-facing identity)
+    const allLabels = [
+      ...numCriteria.map(c => c.label.trim().toLowerCase()),
+      ...flagCriteriaState.map(c => c.label.trim().toLowerCase()),
+    ];
+    if (new Set(allLabels).size !== allLabels.length) {
       setError('Duplicate field labels are not allowed. Labels must be unique.');
       return;
     }
 
-    // Finalize criteria with generated keys
+    // Preserve existing keys so renaming a criterion's label doesn't wipe
+    // student data. Only newly-added criteria (key === '') get a fresh key.
     const finalNumCriteria = numCriteria.map(c => ({
       ...c,
-      key: generateKeyFromLabel(c.label),
+      key: c.key || generateKeyFromLabel(c.label),
       weight: parseFloat(c.weight),
     }));
 
     const finalFlagCriteria = flagCriteriaState.map(c => ({
       ...c,
-      key: generateKeyFromLabel(c.label),
+      key: c.key || generateKeyFromLabel(c.label),
       weight: parseFloat(c.weight),
     }));
 

--- a/src/components/SetupPage.js
+++ b/src/components/SetupPage.js
@@ -356,20 +356,14 @@ function ConstraintButton({ onClick }) {
  * ImportModalWrapper - Provides context data to ImportModal
  */
 function ImportModalWrapper({ onClose, onClearAll }) {
-  const { students, setStudents, addKeepApart, addKeepTogether } = useStudentsExport();
+  const { students, setStudents } = useStudentsExport();
   const { numericCriteria, flagCriteria } = useCriteriaExport();
 
   const handleImport = useCallback(
-    (ss, importedKeepApart, importedKeepTogether) => {
+    ss => {
       setStudents(prev => [...prev, ...ss]);
-      if (importedKeepApart?.length > 0) {
-        importedKeepApart.forEach(pair => addKeepApart(pair[0], pair[1]));
-      }
-      if (importedKeepTogether?.length > 0) {
-        importedKeepTogether.forEach(group => addKeepTogether(group));
-      }
     },
-    [setStudents, addKeepApart, addKeepTogether]
+    [setStudents]
   );
 
   return (

--- a/src/csv.js
+++ b/src/csv.js
@@ -97,7 +97,7 @@ function parseCSV(text, numericCriteria, flagCriteria) {
   // Normalize CRLF and bare CR to LF
   const normalized = text.trim().replace(/\r\n/g, '\n').replace(/\r/g, '\n');
   const lines = normalized.split('\n');
-  if (lines.length < 2) return { students: [], errors: ['No data rows found'], keepApart: [], keepTogether: [], keepOutOfClass: [] };
+  if (lines.length < 2) return { students: [], errors: ['No data rows found'] };
 
   // Normalize headers: lowercase, strip spaces
   const rawHeaders = parseCSVLine(lines[0]);
@@ -162,7 +162,7 @@ function parseCSV(text, numericCriteria, flagCriteria) {
     students.push(parseStudentRow(cols, i, ctx, errors));
   });
 
-  return { students, errors, keepApart: [], keepTogether: [], keepOutOfClass: [] };
+  return { students, errors };
 }
 
 function exportStudentsToCSV(students, numericCriteria, flagCriteria) {

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -1,7 +1,7 @@
 const { useState, useEffect, useRef, useCallback, useMemo } = React;
 
 // App version for save/load compatibility checking
-const APP_VERSION = "1.7.10";
+const APP_VERSION = "1.7.11";
 
 const DEFAULT_NUMERIC_CRITERIA = [
   { key: 'englishlanguageartsscore', label: 'English Language Arts Score', weight: 1.0 },

--- a/src/utils/projectDeserializer.js
+++ b/src/utils/projectDeserializer.js
@@ -494,6 +494,7 @@ function deserializeProject(projectData, options = {}) {
   
   // Build result data
   const resultData = canLoad ? {
+    metadata: data.metadata,
     students: validatedStudents,
     teachers: validatedTeachers,
     numericCriteria: criteriaCheck.mergedNumCriteria,

--- a/tests/criterion-rename.test.js
+++ b/tests/criterion-rename.test.js
@@ -1,0 +1,97 @@
+import { describe, test, expect } from 'vitest';
+
+/**
+ * Regression test for the criterion-rename data-wipe bug.
+ *
+ * Before the fix, SettingsModal regenerated every criterion's `key` from its
+ * `label` on save. Renaming "Reading Score" -> "Reading" produced a new key
+ * (`reading`) that didn't match the old one (`readingscore`); the diff in
+ * handleSaveSettings then treated the criterion as removed-then-added and
+ * deleted the original field from every student.
+ *
+ * The fix: preserve existing keys; only newly-added criteria (empty key)
+ * generate a key from their label.
+ */
+
+// Mirror generateKeyFromLabel from src/defaults.js
+function generateKeyFromLabel(label) {
+  return label
+    .toLowerCase()
+    .replace(/[^a-z0-9]/g, '')
+    .replace(/^(\d)/, '_$1');
+}
+
+// Mirror SettingsModal.handleSave's criterion finalization (post-fix)
+function finalizeCriteria(criteria) {
+  return criteria.map(c => ({
+    ...c,
+    key: c.key || generateKeyFromLabel(c.label),
+    weight: parseFloat(c.weight),
+  }));
+}
+
+// Mirror app.js handleSaveSettings' student-field pruning
+function pruneRemovedFields(students, oldCriteria, newCriteria) {
+  const oldKeys = new Set(oldCriteria.map(c => c.key));
+  const newKeys = new Set(newCriteria.map(c => c.key));
+  const removed = [...oldKeys].filter(k => !newKeys.has(k));
+  if (removed.length === 0) return students;
+  return students.map(s => {
+    const updated = { ...s };
+    removed.forEach(k => delete updated[k]);
+    return updated;
+  });
+}
+
+describe('Criterion rename preserves student data', () => {
+  test('renaming a label keeps the key stable', () => {
+    const edited = [{ key: 'readingscore', label: 'Reading', weight: 1.0 }];
+    const finalized = finalizeCriteria(edited);
+    expect(finalized[0].key).toBe('readingscore');
+  });
+
+  test('renaming a label does not wipe the corresponding student field', () => {
+    const oldCriteria = [{ key: 'readingscore', label: 'Reading Score', weight: 1.0 }];
+    const edited = [{ key: 'readingscore', label: 'Reading', weight: 1.0 }];
+    const finalized = finalizeCriteria(edited);
+
+    const students = [
+      { id: 's1', name: 'Alice', gender: 'F', readingscore: 85 },
+      { id: 's2', name: 'Bob', gender: 'M', readingscore: 72 },
+    ];
+    const pruned = pruneRemovedFields(students, oldCriteria, finalized);
+
+    expect(pruned[0].readingscore).toBe(85);
+    expect(pruned[1].readingscore).toBe(72);
+  });
+
+  test('newly-added criterion gets a generated key from its label', () => {
+    const edited = [
+      { key: 'readingscore', label: 'Reading Score', weight: 1.0 },
+      { key: '', label: 'Writing Score', weight: 1.0 },
+    ];
+    const finalized = finalizeCriteria(edited);
+    expect(finalized[1].key).toBe('writingscore');
+  });
+
+  test('explicitly removed criterion still wipes its field on students', () => {
+    const oldCriteria = [
+      { key: 'readingscore', label: 'Reading Score', weight: 1.0 },
+      { key: 'mathscore', label: 'Math Score', weight: 1.0 },
+    ];
+    const edited = [{ key: 'readingscore', label: 'Reading Score', weight: 1.0 }];
+    const finalized = finalizeCriteria(edited);
+
+    const students = [{ id: 's1', readingscore: 85, mathscore: 72 }];
+    const pruned = pruneRemovedFields(students, oldCriteria, finalized);
+
+    expect(pruned[0].readingscore).toBe(85);
+    expect(pruned[0].mathscore).toBeUndefined();
+  });
+
+  test('label starting with a digit produces a valid key', () => {
+    const edited = [{ key: '', label: '504', weight: 1.0 }];
+    const finalized = finalizeCriteria(edited);
+    expect(finalized[0].key).toBe('_504');
+  });
+});

--- a/tests/csv.test.js
+++ b/tests/csv.test.js
@@ -509,10 +509,11 @@ Bob,F,`;
       expect(result.students[0].behavior).toBe(true);
       expect(result.students[1].name).toBe('Bob');
       expect(result.students[1].sped).toBe(true);
-      // Constraints are no longer exported/imported via CSV
-      expect(result.keepApart).toEqual([]);
-      expect(result.keepTogether).toEqual([]);
-      expect(result.keepOutOfClass).toEqual([]);
+      // Constraints are no longer exported/imported via CSV; parseCSV does
+      // not return constraint fields at all.
+      expect(result.keepApart).toBeUndefined();
+      expect(result.keepTogether).toBeUndefined();
+      expect(result.keepOutOfClass).toBeUndefined();
     });
   });
 


### PR DESCRIPTION
Follow-up to #63. Addresses the four deferred items.

## Bug fixes

### 1. Criterion rename no longer wipes student data
Before: SettingsModal regenerated every criterion's `key` from its `label` on save. Renaming "Reading Score" → "Reading" produced a new key (`reading`) that didn't match the old one (`readingscore`); the diff in `handleSaveSettings` then treated the criterion as remove+add and deleted the field from every student.

After: keys are stable once assigned. Only newly-added criteria (empty key) generate a fresh key from their label. Duplicate-check now compares labels directly.

Behavioral note: renaming preserves data. To get a fresh column, delete + add — same as before.

**Files:** [src/components/SettingsModal.js](src/components/SettingsModal.js#L163-L189)
**Test:** new [tests/criterion-rename.test.js](tests/criterion-rename.test.js) covers rename, add, remove, and digit-prefixed labels.

### 2. Project version / saved-date info now renders on load
Before: [LoadProjectModal.renderVersionInfo()](src/components/LoadProjectModal.js#L127) read `validationResult.data?._raw.metadata` — but the deserializer never produced a `_raw` field, so the info block silently never rendered.

After: [projectDeserializer.js](src/utils/projectDeserializer.js#L496) includes `metadata: data.metadata` in `resultData`; the modal reads it directly.

## Cleanups (residual dead plumbing from #62)

### 3. CSV constraint plumbing
`parseCSV` returned empty `keepApart` / `keepTogether` / `keepOutOfClass` arrays that `ImportModal` destructured and `SetupPage` conditionally added — all unreachable code paths since #62 removed CSV constraint columns.

**Removed from:**
- [src/csv.js:100,165](src/csv.js#L100) — empty-array returns
- [src/components/ImportModal.js:123,128](src/components/ImportModal.js#L123) — destructure + forward
- [src/components/SetupPage.js:359-373](src/components/SetupPage.js#L359) — `ImportModalWrapper` constraint plumbing and unused `addKeepApart`/`addKeepTogether`
- [tests/csv.test.js:512-515](tests/csv.test.js#L512) — assertion updated to match new shape

### 4. README doc drift
README still documented `keep_apart_group` / `keep_together_group` CSV columns and claimed CSV could persist constraints. Updated [README.md:71-82,162](README.md#L71-L82): removed the constraint-column docs, updated the example CSV, clarified that constraints persist via Save Project (JSON) only.

## Effect hygiene

### 5. `OptimizePage.handleReoptimize`
- Wrapped in `useCallback` so it's a stable reference.
- The auto-reoptimize effect ([OptimizePage.js:97-105](src/components/OptimizePage.js#L97-L105)) has intentional partial deps (criteria only) — adding assignment/optimizing/handleReoptimize would re-trigger every reoptimize result and cause a runaway loop. Added a comment explaining this and a targeted `eslint-disable-next-line react-hooks/exhaustive-deps`.

## Version

`package.json` and `src/defaults.js APP_VERSION` bumped 1.7.10 → 1.7.11.

## Test plan

- [x] `npm run lint` — 0 errors (121 pre-existing warnings, one fewer than main)
- [x] `npm test` — 167/167 passing (5 new tests in `criterion-rename.test.js`)
- [x] `npm run build` — succeeds, output `dist/class-list-builder-v1.7.11.html`
- [ ] Manual: rename a criterion label with student data present → data preserved
- [ ] Manual: open Load Project modal with a JSON file → version/saved-date info renders
- [ ] Manual: import a CSV → no regression
- [ ] Manual: change criteria weights on Optimize page → auto-reoptimize still fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)